### PR TITLE
Add job retrieval by ID for PDF generation

### DIFF
--- a/backend/src/routes.js
+++ b/backend/src/routes.js
@@ -32,6 +32,20 @@ router.get('/jobs/latest', async (req, res) => {
   }
 });
 
+// Get a job by ID
+router.get('/jobs/:jobId', async (req, res) => {
+  const jobId = req.params.jobId;
+  try {
+    const result = await pool.query('SELECT * FROM jobs WHERE id = $1', [jobId]);
+    if (result.rows.length === 0) {
+      return res.status(404).json({ error: 'Job not found' });
+    }
+    res.json(result.rows[0]);
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
 // Import frames via CSV
 router.post('/frames/import/:jobId', upload.single('file'), (req, res) => {
   const jobId = req.params.jobId;

--- a/frontend/js/app.js
+++ b/frontend/js/app.js
@@ -44,7 +44,7 @@ document.getElementById('uploadDoors').addEventListener('click', async () => {
 document.getElementById('generatePdf').addEventListener('click', async () => {
   if (!latestJobId) return alert('Save a job first!');
 
-  const jobRes = await fetch(`${API_BASE}/api/jobs/latest`);
+  const jobRes = await fetch(`${API_BASE}/api/jobs/${latestJobId}`);
   const job = await jobRes.json();
 
   const framesRes = await fetch(`${API_BASE}/api/frames/job/${latestJobId}`);


### PR DESCRIPTION
## Summary
- expose `/jobs/:jobId` endpoint on the backend for retrieving a specific job
- update PDF generation to request job info by ID instead of relying on latest

## Testing
- `npm test` *(fails: Missing script "test")*
- `node --check src/routes.js`
- `node --check frontend/js/app.js`


------
https://chatgpt.com/codex/tasks/task_e_689d3646a44483298b11c3f2dcc380dd