### PR TITLE
refactor(frontend): externalize styles

### DIFF
--- a/frontend/css/style.css
+++ b/frontend/css/style.css
@@ -1,11 +1,115 @@
 body {
   font-family: Arial, sans-serif;
-  padding: 20px;
+  padding: 18px;
+  max-width: 1200px;
 }
 
-input, button {
-  margin: 5px;
+label {
+  display: block;
+  margin-top: 8px;
+  font-weight: 600;
+}
+
+input[type="text"], select {
+  width: 100%;
+  padding: 6px;
+  margin: 0;
+}
+
+textarea {
+  width: 100%;
+  min-height: 60px;
+  padding: 6px;
+}
+
+button {
+  margin: 8px 0 0 0;
+  padding: 8px 12px;
+  cursor: pointer;
+}
+
+.row {
+  display: flex;
+  gap: 12px;
+}
+
+.col {
+  flex: 1;
+}
+
+.panel {
+  border: 1px solid #ddd;
+  padding: 12px;
+  border-radius: 6px;
+  background: #fafafa;
+  margin-top: 12px;
+}
+
+.list {
+  margin-top: 8px;
+  border: 1px solid #eee;
   padding: 8px;
+  max-height: 260px;
+  overflow: auto;
+  background: white;
+}
+
+.item {
+  border-bottom: 1px dashed #eee;
+  padding: 6px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.muted {
+  color: #666;
+  font-size: 13px;
+}
+
+.action-buttons {
+  margin-top: 8px;
+}
+
+.section {
+  margin-top: 12px;
+}
+
+.file-input {
+  display: inline-block;
+  margin: 0 0 0 8px;
+}
+
+.job-select {
+  width: 100%;
+  margin-top: 8px;
+}
+
+.note {
+  margin-top: 12px;
+}
+
+.modal-overlay {
+  display: none;
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.4);
+  align-items: center;
+  justify-content: center;
+}
+
+.modal-body {
+  background: white;
+  padding: 16px;
+  border-radius: 6px;
+  width: 600px;
+  max-height: 80vh;
+  overflow: auto;
+}
+
+.modal-actions {
+  margin-top: 12px;
+  text-align: right;
 }
 
 h1, h2 {

--- a/frontend/css/style.css
+++ b/frontend/css/style.css
@@ -1,43 +1,58 @@
 body {
   font-family: Arial, sans-serif;
+  padding: 20px;
+}
+
+input, button {
+  margin: 5px;
+  padding: 8px;
+}
+
+h1, h2 {
+  color: #333;
+}
+
+/* Frontend-specific styles */
+body.frontend {
   padding: 18px;
   max-width: 1200px;
 }
 
-label {
+body.frontend label {
   display: block;
   margin-top: 8px;
   font-weight: 600;
 }
 
-input[type="text"], select {
+body.frontend input[type="text"],
+body.frontend select {
   width: 100%;
   padding: 6px;
   margin: 0;
 }
 
-textarea {
+body.frontend textarea {
   width: 100%;
   min-height: 60px;
   padding: 6px;
 }
 
-button {
-  margin: 8px 0 0 0;
+body.frontend button {
+  margin-top: 8px;
   padding: 8px 12px;
   cursor: pointer;
 }
 
-.row {
+body.frontend .row {
   display: flex;
   gap: 12px;
 }
 
-.col {
+body.frontend .col {
   flex: 1;
 }
 
-.panel {
+body.frontend .panel {
   border: 1px solid #ddd;
   padding: 12px;
   border-radius: 6px;
@@ -45,7 +60,7 @@ button {
   margin-top: 12px;
 }
 
-.list {
+body.frontend .list {
   margin-top: 8px;
   border: 1px solid #eee;
   padding: 8px;
@@ -54,7 +69,7 @@ button {
   background: white;
 }
 
-.item {
+body.frontend .item {
   border-bottom: 1px dashed #eee;
   padding: 6px;
   display: flex;
@@ -62,34 +77,34 @@ button {
   align-items: center;
 }
 
-.muted {
+body.frontend .muted {
   color: #666;
   font-size: 13px;
 }
 
-.action-buttons {
+body.frontend .action-buttons {
   margin-top: 8px;
 }
 
-.section {
+body.frontend .section {
   margin-top: 12px;
 }
 
-.file-input {
+body.frontend .file-input {
   display: inline-block;
-  margin: 0 0 0 8px;
+  margin-left: 8px;
 }
 
-.job-select {
+body.frontend .job-select {
   width: 100%;
   margin-top: 8px;
 }
 
-.note {
+body.frontend .note {
   margin-top: 12px;
 }
 
-.modal-overlay {
+body.frontend .modal-overlay {
   display: none;
   position: fixed;
   inset: 0;
@@ -98,7 +113,7 @@ button {
   justify-content: center;
 }
 
-.modal-body {
+body.frontend .modal-body {
   background: white;
   padding: 16px;
   border-radius: 6px;
@@ -107,11 +122,8 @@ button {
   overflow: auto;
 }
 
-.modal-actions {
+body.frontend .modal-actions {
   margin-top: 12px;
   text-align: right;
 }
 
-h1, h2 {
-  color: #333;
-}

--- a/frontend/frontend.html
+++ b/frontend/frontend.html
@@ -6,7 +6,7 @@
   <link rel="stylesheet" href="css/style.css" />
   <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>
 </head>
-<body>
+<body class="frontend">
   <h1>Job Manager (Frontend)</h1>
   <div class="row">
     <div class="col panel">

--- a/frontend/frontend.html
+++ b/frontend/frontend.html
@@ -3,20 +3,8 @@
 <head>
   <meta charset="utf-8" />
   <title>Job Manager (Frontend)</title>
+  <link rel="stylesheet" href="css/style.css" />
   <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>
-  <style>
-    body { font-family: Arial, sans-serif; padding:18px; max-width:1200px; }
-    label { display:block; margin-top:8px; font-weight:600; }
-    input[type="text"], select { width:100%; padding:6px; }
-    textarea { width:100%; min-height:60px; padding:6px; }
-    button { margin-top:8px; padding:8px 12px; cursor:pointer; }
-    .row { display:flex; gap:12px; }
-    .col { flex:1; }
-    .panel { border:1px solid #ddd; padding:12px; border-radius:6px; background:#fafafa; margin-top:12px; }
-    .list { margin-top:8px; border:1px solid #eee; padding:8px; max-height:260px; overflow:auto; background:white; }
-    .item { border-bottom:1px dashed #eee; padding:6px; display:flex; justify-content:space-between; align-items:center; }
-    .muted { color:#666; font-size:13px; }
-  </style>
 </head>
 <body>
   <h1>Job Manager (Frontend)</h1>
@@ -31,23 +19,23 @@
       <input id="pm" type="text" />
       <label>Work Order #</label>
       <input id="workOrder" type="text" />
-      <div style="margin-top:8px;">
+      <div class="action-buttons">
         <button id="saveJob">Save Job</button>
         <button id="loadJobs">Refresh Job List</button>
       </div>
 
-      <div style="margin-top:12px;">
+      <div class="section">
         <h3>Frames</h3>
         <button id="addFrame">Add Frame (manual)</button>
-        <input id="framesCsv" type="file" accept=".csv" style="display:inline-block; margin-left:8px;" />
+        <input id="framesCsv" type="file" accept=".csv" class="file-input" />
         <button id="importFramesBtn">Import Frames CSV</button>
         <div id="framesList" class="list"></div>
       </div>
 
-      <div style="margin-top:12px;">
+      <div class="section">
         <h3>Doors</h3>
         <button id="addDoor">Add Door (manual)</button>
-        <input id="doorsCsv" type="file" accept=".csv" style="display:inline-block; margin-left:8px;" />
+        <input id="doorsCsv" type="file" accept=".csv" class="file-input" />
         <button id="importDoorsBtn">Import Doors CSV</button>
         <div id="doorsList" class="list"></div>
       </div>
@@ -57,28 +45,28 @@
       <h2>Jobs</h2>
       <label>Filter</label>
       <input id="filterJobs" type="text" placeholder="type job number or name..." />
-      <select id="jobsSelect" size="10" style="width:100%; margin-top:8px;"></select>
-      <div style="margin-top:8px;">
+      <select id="jobsSelect" size="10" class="job-select"></select>
+      <div class="action-buttons">
         <button id="loadSelected">Load Selected</button>
         <button id="deleteSelected">Delete Selected</button>
         <button id="exportPdfSelected">Export PDF (selected)</button>
       </div>
-      <div style="margin-top:12px;">
+      <div class="section">
         <button id="exportJsonDownload">Download All Data (JSON)</button>
       </div>
-      <div class="muted" style="margin-top:12px;">
+      <div class="muted note">
         Note: CSV import is done server-side and stored in Postgres. PDF generation happens in your browser using jsPDF.
       </div>
     </div>
   </div>
 
 <!-- small modal for custom KV entry -->
-<div id="modal" style="display:none; position:fixed; inset:0; background:rgba(0,0,0,0.4); align-items:center; justify-content:center;">
-  <div style="background:white; padding:16px; border-radius:6px; width:600px; max-height:80vh; overflow:auto;">
+<div id="modal" class="modal-overlay">
+  <div class="modal-body">
     <h3 id="modalTitle">Add Item</h3>
     <div id="kvContainer"></div>
     <button id="addKVbtn">Add field</button>
-    <div style="margin-top:12px; text-align:right;">
+    <div class="modal-actions">
       <button id="modalSave">Save</button>
       <button id="modalCancel">Cancel</button>
     </div>


### PR DESCRIPTION
## Summary
- link shared stylesheet in frontend.html and drop inline style tag
- move inline styles to css and replace with semantic classes

## Testing
- `cd backend && npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689d46baa9e883299a98ae9cf2da434d