### PR TITLE
Refine frontend form styling and ignore dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+**/node_modules/
+*.log
+npm-debug.log

--- a/frontend/css/style.css
+++ b/frontend/css/style.css
@@ -12,15 +12,29 @@ body {
   padding: 20px;
   background-color: var(--vos-gray);
   color: var(--vos-dark);
+  max-width: 1200px;
 }
 
 h1, h2, h3 {
   color: var(--vos-red);
 }
 
-input, button, select, textarea {
-  margin: 5px;
-  padding: 8px;
+label {
+  display: block;
+  margin-top: 8px;
+  font-weight: 600;
+}
+
+input[type="text"],
+select,
+textarea {
+  width: 100%;
+  padding: 6px;
+  margin-top: 4px;
+}
+
+textarea {
+  min-height: 60px;
 }
 
 .panel {
@@ -32,6 +46,8 @@ input, button, select, textarea {
 }
 
 button {
+  margin-top: 8px;
+  padding: 8px 12px;
   background-color: var(--vos-red);
   border: 1px solid var(--vos-red);
   color: var(--vos-white);
@@ -45,6 +61,15 @@ button:focus {
   border-color: var(--vos-red-dark);
   color: var(--vos-white);
   outline: 2px solid var(--vos-gray);
+}
+
+.row {
+  display: flex;
+  gap: 12px;
+}
+
+.col {
+  flex: 1;
 }
 
 .list {
@@ -68,99 +93,34 @@ button:focus {
   border-bottom: none;
 }
 
-/* Frontend-specific styles */
-body.frontend {
-  padding: 18px;
-  max-width: 1200px;
-}
-
-body.frontend label {
-  display: block;
-  margin-top: 8px;
-  font-weight: 600;
-}
-
-body.frontend input[type="text"],
-body.frontend select {
-  width: 100%;
-  padding: 6px;
-  margin: 0;
-}
-
-body.frontend textarea {
-  width: 100%;
-  min-height: 60px;
-  padding: 6px;
-}
-
-body.frontend button {
-  margin-top: 8px;
-  padding: 8px 12px;
-  cursor: pointer;
-}
-
-body.frontend .row {
-  display: flex;
-  gap: 12px;
-}
-
-body.frontend .col {
-  flex: 1;
-}
-
-body.frontend .panel {
-  border: 1px solid #ddd;
-  padding: 12px;
-  border-radius: 6px;
-  background: #fafafa;
-  margin-top: 12px;
-}
-
-body.frontend .list {
-  margin-top: 8px;
-  border: 1px solid #eee;
-  padding: 8px;
-  max-height: 260px;
-  overflow: auto;
-  background: white;
-}
-
-body.frontend .item {
-  border-bottom: 1px dashed #eee;
-  padding: 6px;
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-}
-
-body.frontend .muted {
+.muted {
   color: #666;
   font-size: 13px;
 }
 
-body.frontend .action-buttons {
+.action-buttons {
   margin-top: 8px;
 }
 
-body.frontend .section {
+.section {
   margin-top: 12px;
 }
 
-body.frontend .file-input {
+.file-input {
   display: inline-block;
   margin-left: 8px;
 }
 
-body.frontend .job-select {
+.job-select {
   width: 100%;
   margin-top: 8px;
 }
 
-body.frontend .note {
+.note {
   margin-top: 12px;
 }
 
-body.frontend .modal-overlay {
+.modal-overlay {
   display: none;
   position: fixed;
   inset: 0;
@@ -169,7 +129,7 @@ body.frontend .modal-overlay {
   justify-content: center;
 }
 
-body.frontend .modal-body {
+.modal-body {
   background: white;
   padding: 16px;
   border-radius: 6px;
@@ -178,7 +138,7 @@ body.frontend .modal-body {
   overflow: auto;
 }
 
-body.frontend .modal-actions {
+.modal-actions {
   margin-top: 12px;
   text-align: right;
 }

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -2,7 +2,8 @@
 <html>
 <head>
   <meta charset="utf-8" />
-   
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+
   <title>Job Manager (Frontend)</title>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>
 <link rel="stylesheet" href="css/style.css" />
@@ -20,24 +21,28 @@
       <input id="pm" type="text" />
       <label>Work Order #</label>
       <input id="workOrder" type="text" />
-      <div style="margin-top:8px;">
+      <div class="action-buttons">
         <button id="saveJob">Save Job</button>
         <button id="loadJobs">Refresh Job List</button>
       </div>
 
-      <div style="margin-top:12px;">
+      <div class="section">
         <h3>Frames</h3>
-        <button id="addFrame">Add Frame (manual)</button>
-        <input id="framesCsv" type="file" accept=".csv" style="display:inline-block; margin-left:8px;" />
-        <button id="importFramesBtn">Import Frames CSV</button>
+        <div class="action-buttons">
+          <button id="addFrame">Add Frame (manual)</button>
+          <input id="framesCsv" type="file" accept=".csv" class="file-input" />
+          <button id="importFramesBtn">Import Frames CSV</button>
+        </div>
         <div id="framesList" class="list"></div>
       </div>
 
-      <div style="margin-top:12px;">
+      <div class="section">
         <h3>Doors</h3>
-        <button id="addDoor">Add Door (manual)</button>
-        <input id="doorsCsv" type="file" accept=".csv" style="display:inline-block; margin-left:8px;" />
-        <button id="importDoorsBtn">Import Doors CSV</button>
+        <div class="action-buttons">
+          <button id="addDoor">Add Door (manual)</button>
+          <input id="doorsCsv" type="file" accept=".csv" class="file-input" />
+          <button id="importDoorsBtn">Import Doors CSV</button>
+        </div>
         <div id="doorsList" class="list"></div>
       </div>
     </div>
@@ -46,28 +51,28 @@
       <h2>Jobs</h2>
       <label>Filter</label>
       <input id="filterJobs" type="text" placeholder="type job number or name..." />
-      <select id="jobsSelect" size="10" style="width:100%; margin-top:8px;"></select>
-      <div style="margin-top:8px;">
+      <select id="jobsSelect" size="10" class="job-select"></select>
+      <div class="action-buttons">
         <button id="loadSelected">Load Selected</button>
         <button id="deleteSelected">Delete Selected</button>
         <button id="exportPdfSelected">Export PDF (selected)</button>
       </div>
-      <div style="margin-top:12px;">
+      <div class="section">
         <button id="exportJsonDownload">Download All Data (JSON)</button>
       </div>
-      <div class="muted" style="margin-top:12px;">
+      <div class="muted note">
         Note: CSV import is done server-side and stored in Postgres. PDF generation happens in your browser using jsPDF.
       </div>
     </div>
   </div>
 
 <!-- small modal for custom KV entry -->
-<div id="modal" style="display:none; position:fixed; inset:0; background:rgba(0,0,0,0.4); align-items:center; justify-content:center;">
-  <div style="background:white; padding:16px; border-radius:6px; width:600px; max-height:80vh; overflow:auto;">
+<div id="modal" class="modal-overlay">
+  <div class="modal-body">
     <h3 id="modalTitle">Add Item</h3>
     <div id="kvContainer"></div>
     <button id="addKVbtn">Add field</button>
-    <div style="margin-top:12px; text-align:right;">
+    <div class="modal-actions">
       <button id="modalSave">Save</button>
       <button id="modalCancel">Cancel</button>
     </div>


### PR DESCRIPTION
## Summary
- Add `.gitignore` to omit node modules and logs
- Replace inline styles in `index.html` with semantic classes and responsive meta tag
- Consolidate `style.css` into a reusable, brand-themed layout

## Testing
- `cd backend && npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689d525a82ec832986fcf39a306ed941