### PR TITLE
Add dark mode, job archiving, and job ID handling

### DIFF
--- a/backend/migrations.sql
+++ b/backend/migrations.sql
@@ -1,10 +1,12 @@
 CREATE TABLE IF NOT EXISTS jobs (
     id SERIAL PRIMARY KEY,
-    job_number VARCHAR(50) UNIQUE,
+    job_number VARCHAR(50),
     job_name VARCHAR(255),
     pm VARCHAR(255),
     work_order VARCHAR(50),
-    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+    archived BOOLEAN DEFAULT FALSE,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE (job_number, work_order)
 );
 
 CREATE TABLE IF NOT EXISTS frames (

--- a/frontend/css/style.css
+++ b/frontend/css/style.css
@@ -15,6 +15,11 @@ body {
   max-width: 1200px;
 }
 
+body.dark {
+  background-color: var(--vos-dark);
+  color: var(--vos-gray);
+}
+
 h1, h2, h3 {
   color: var(--vos-red);
 }
@@ -25,12 +30,23 @@ label {
   font-weight: 600;
 }
 
+label.checkbox {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+}
+
 input[type="text"],
 select,
 textarea {
   width: 100%;
   padding: 6px;
   margin-top: 4px;
+}
+
+input[type="checkbox"] {
+  width: auto;
 }
 
 textarea {
@@ -43,6 +59,22 @@ textarea {
   border-radius: 6px;
   padding: 12px;
   margin-top: 12px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.panel label,
+.panel input[type="text"],
+.panel select,
+.panel textarea {
+  width: 90%;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.panel label {
+  text-align: center;
 }
 
 button {
@@ -61,6 +93,35 @@ button:focus {
   border-color: var(--vos-red-dark);
   color: var(--vos-white);
   outline: 2px solid var(--vos-gray);
+}
+
+body.dark .panel {
+  background-color: #333;
+  color: var(--vos-gray);
+}
+
+body.dark .list {
+  background-color: #333;
+}
+
+body.dark input[type="text"],
+body.dark select,
+body.dark textarea {
+  background-color: #555;
+  color: var(--vos-gray);
+  border: 1px solid var(--vos-gray);
+}
+
+body.dark button {
+  background-color: var(--vos-red-dark);
+  border-color: var(--vos-red-dark);
+}
+
+body.dark button:hover,
+body.dark button:focus {
+  background-color: var(--vos-red);
+  border-color: var(--vos-red);
+  color: var(--vos-white);
 }
 
 .row {
@@ -100,6 +161,14 @@ button:focus {
 
 .action-buttons {
   margin-top: 8px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  justify-content: center;
+}
+
+.action-buttons button {
+  margin-top: 0;
 }
 
 .section {

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -10,9 +10,11 @@
 </head>
 <body>
   <h1>Job Manager (Frontend)</h1>
+  <button id="toggleDarkMode">Toggle Dark Mode</button>
   <div class="row">
     <div class="col panel">
       <h2>Job Info</h2>
+      <input id="jobId" type="hidden" />
       <label>Job Number</label>
       <input id="jobNumber" type="text" />
       <label>Job Name</label>
@@ -21,6 +23,7 @@
       <input id="pm" type="text" />
       <label>Work Order #</label>
       <input id="workOrder" type="text" />
+      <label class="checkbox"><input id="archived" type="checkbox" /> Archived</label>
       <div class="action-buttons">
         <button id="saveJob">Save Job</button>
         <button id="loadJobs">Refresh Job List</button>
@@ -51,6 +54,7 @@
       <h2>Jobs</h2>
       <label>Filter</label>
       <input id="filterJobs" type="text" placeholder="type job number or name..." />
+      <label class="checkbox"><input id="viewArchived" type="checkbox" /> View Archived</label>
       <select id="jobsSelect" size="10" class="job-select"></select>
       <div class="action-buttons">
         <button id="loadSelected">Load Selected</button>


### PR DESCRIPTION
## Summary
- add dark mode theme toggle and centered input layouts
- allow archiving jobs and viewing archived entries
- switch job operations to use job IDs instead of job numbers

## Testing
- `cd backend && npm test` (fails: Missing script: "test")
- `cd ../frontend && npm test` (fails: ENOENT package.json)


------
https://chatgpt.com/codex/tasks/task_e_689d55f4f71083299c761357f7efb5ec