### PR TITLE
Enable nested work orders and entry editing

### DIFF
--- a/backend/src/routes.js
+++ b/backend/src/routes.js
@@ -145,4 +145,30 @@ router.delete('/doors/:id', async (req, res) => {
   }
 });
 
+// Update frame data
+router.put('/frames/:id', async (req, res) => {
+  const id = req.params.id;
+  const { data } = req.body;
+  try {
+    const result = await pool.query('UPDATE frames SET data = $1 WHERE id = $2 RETURNING *', [data, id]);
+    if (result.rowCount === 0) return res.status(404).json({ error: 'Frame not found' });
+    res.json({ frame: result.rows[0] });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+// Update door data
+router.put('/doors/:id', async (req, res) => {
+  const id = req.params.id;
+  const { data } = req.body;
+  try {
+    const result = await pool.query('UPDATE doors SET data = $1 WHERE id = $2 RETURNING *', [data, id]);
+    if (result.rowCount === 0) return res.status(404).json({ error: 'Door not found' });
+    res.json({ door: result.rows[0] });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
 module.exports = router;

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -21,32 +21,27 @@
       <input id="jobName" type="text" />
       <label>PM</label>
       <input id="pm" type="text" />
-      <label>Work Order #</label>
-      <input id="workOrder" type="text" />
       <label class="checkbox"><input id="archived" type="checkbox" /> Archived</label>
       <div class="action-buttons">
         <button id="saveJob">Save Job</button>
         <button id="loadJobs">Refresh Job List</button>
       </div>
-
+      
       <div class="section">
-        <h3>Frames</h3>
+        <h3>Work Orders</h3>
         <div class="action-buttons">
-          <button id="addFrame">Add Frame (manual)</button>
-          <input id="framesCsv" type="file" accept=".csv" class="file-input" />
-          <button id="importFramesBtn">Import Frames CSV</button>
+          <input id="newWorkOrder" type="text" placeholder="Work Order #" />
+          <button id="addWorkOrder">Add Work Order</button>
         </div>
-        <div id="framesList" class="list"></div>
+        <div id="workOrdersList" class="list"></div>
       </div>
 
       <div class="section">
-        <h3>Doors</h3>
+        <h3>Entries</h3>
         <div class="action-buttons">
-          <button id="addDoor">Add Door (manual)</button>
-          <input id="doorsCsv" type="file" accept=".csv" class="file-input" />
-          <button id="importDoorsBtn">Import Doors CSV</button>
+          <button id="addEntry">Add Entry</button>
         </div>
-        <div id="doorsList" class="list"></div>
+        <div id="entriesList" class="list"></div>
       </div>
     </div>
 

--- a/frontend/js/app.js
+++ b/frontend/js/app.js
@@ -1,4 +1,4 @@
-const API_BASE = 'http://192.168.4.251:3000'; // if frontend served from same origin, keep ''. If server on different origin, put e.g. 'http://localhost:4000'
+const API_BASE = 'http://192.168.4.251:3000'; // if frontend served from same origin, keep ''.
 function api(path, opts = {}) {
   return fetch(API_BASE + '/api' + path, opts).then(async r => {
     const txt = await r.text();
@@ -6,73 +6,68 @@ function api(path, opts = {}) {
   });
 }
 
-/* UI helpers */
 let loadedJob = null;
+let selectedWorkOrderId = null;
 
-async function refreshJobList(filter='', includeArchived=false) {
+async function refreshJobList(filter = '', includeArchived = false) {
   const { json } = await api('/jobs?includeArchived=' + includeArchived);
   const sel = document.getElementById('jobsSelect');
   sel.innerHTML = '';
   json.jobs.filter(j => {
-    const txt = `${j.job_number} ${j.job_name || ''} ${j.work_order || ''}`.toLowerCase();
+    const txt = `${j.job_number} ${j.job_name || ''}`.toLowerCase();
     return !filter || txt.includes(filter.toLowerCase());
   }).forEach(j => {
     const opt = document.createElement('option');
     opt.value = j.id;
-    const wo = j.work_order ? ` WO ${j.work_order}` : '';
-    opt.textContent = `${j.job_number}${wo} — ${j.job_name || ''}${j.archived ? ' (archived)' : ''}`;
+    opt.textContent = `${j.job_number} — ${j.job_name || ''}${j.archived ? ' (archived)' : ''}`;
     sel.appendChild(opt);
   });
 }
 
 const viewArchivedEl = document.getElementById('viewArchived');
-document.getElementById('loadJobs').addEventListener('click', ()=> refreshJobList(document.getElementById('filterJobs').value, viewArchivedEl.checked));
-document.getElementById('filterJobs').addEventListener('input', (e)=> refreshJobList(e.target.value, viewArchivedEl.checked));
-viewArchivedEl.addEventListener('change', ()=> refreshJobList(document.getElementById('filterJobs').value, viewArchivedEl.checked));
+document.getElementById('loadJobs').addEventListener('click', () => refreshJobList(document.getElementById('filterJobs').value, viewArchivedEl.checked));
+document.getElementById('filterJobs').addEventListener('input', (e) => refreshJobList(e.target.value, viewArchivedEl.checked));
+viewArchivedEl.addEventListener('change', () => refreshJobList(document.getElementById('filterJobs').value, viewArchivedEl.checked));
 
-document.getElementById('saveJob').addEventListener('click', async ()=>{
+document.getElementById('saveJob').addEventListener('click', async () => {
   const jobNumber = document.getElementById('jobNumber').value.trim();
   if (!jobNumber) return alert('Job Number required');
   const payload = {
     jobNumber,
     jobName: document.getElementById('jobName').value,
     pm: document.getElementById('pm').value,
-    workOrder: document.getElementById('workOrder').value,
     archived: document.getElementById('archived').checked
   };
-  const res = await api('/jobs', { method: 'POST', headers:{'content-type':'application/json'}, body: JSON.stringify(payload) });
+  const res = await api('/jobs', { method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify(payload) });
   if (!res.ok) return alert('Save failed');
-  loadedJob = { job: res.json.job }; // minimal
+  loadedJob = { job: res.json.job, workOrders: [] };
   document.getElementById('jobId').value = res.json.job.id;
   alert('Saved');
   refreshJobList(document.getElementById('filterJobs').value, viewArchivedEl.checked);
 });
 
-/* load selected job */
-document.getElementById('loadSelected').addEventListener('click', async ()=>{
+document.getElementById('loadSelected').addEventListener('click', async () => {
   const sel = document.getElementById('jobsSelect');
   if (!sel.value) return alert('Select job');
   const r = await api('/jobs/' + encodeURIComponent(sel.value));
   if (!r.ok) return alert('Failed to load job');
   const data = r.json;
   loadedJob = data;
-  // populate form
+  selectedWorkOrderId = null;
   document.getElementById('jobId').value = data.job.id;
   document.getElementById('jobNumber').value = data.job.job_number || '';
   document.getElementById('jobName').value = data.job.job_name || '';
   document.getElementById('pm').value = data.job.pm || '';
-  document.getElementById('workOrder').value = data.job.work_order || '';
   document.getElementById('archived').checked = !!data.job.archived;
-  renderFrames(data.frames);
-  renderDoors(data.doors);
+  renderWorkOrders(data.workOrders);
+  renderEntries([]);
 });
 
-/* delete selected job */
-document.getElementById('deleteSelected').addEventListener('click', async ()=>{
+document.getElementById('deleteSelected').addEventListener('click', async () => {
   const sel = document.getElementById('jobsSelect');
   if (!sel.value) return alert('Select job');
   if (!confirm('Delete job ' + sel.value + '?')) return;
-  const r = await api('/jobs/' + encodeURIComponent(sel.value), { method:'DELETE' });
+  const r = await api('/jobs/' + encodeURIComponent(sel.value), { method: 'DELETE' });
   if (!r.ok) return alert('Delete failed');
   alert('Deleted');
   refreshJobList(document.getElementById('filterJobs').value, viewArchivedEl.checked);
@@ -81,204 +76,162 @@ document.getElementById('deleteSelected').addEventListener('click', async ()=>{
 
 function clearLoaded() {
   loadedJob = null;
-  document.getElementById('framesList').innerHTML = '';
-  document.getElementById('doorsList').innerHTML = '';
+  selectedWorkOrderId = null;
+  document.getElementById('workOrdersList').innerHTML = '';
+  document.getElementById('entriesList').innerHTML = '';
   document.getElementById('jobNumber').value = '';
   document.getElementById('jobName').value = '';
   document.getElementById('pm').value = '';
-  document.getElementById('workOrder').value = '';
   document.getElementById('jobId').value = '';
   document.getElementById('archived').checked = false;
 }
 
-/* render lists */
-function renderFrames(frames = []) {
-  const el = document.getElementById('framesList');
+function renderWorkOrders(workOrders = []) {
+  const el = document.getElementById('workOrdersList');
   el.innerHTML = '';
-  (frames || []).forEach((f, idx) => {
+  (workOrders || []).forEach(wo => {
     const item = document.createElement('div');
     item.className = 'item';
     const left = document.createElement('div');
-    left.innerHTML = `<strong>Frame ${idx+1}</strong><div class="muted">${Object.entries(f.data || f).slice(0,2).map(kv=>kv.join(': ')).join(' — ')}</div>`;
+    left.innerHTML = `<strong>WO ${wo.work_order}</strong>`;
     const right = document.createElement('div');
-    const edit = document.createElement('button'); edit.textContent='Edit'; edit.onclick = ()=> openModalForEdit('frame', f, idx);
-    const del = document.createElement('button'); del.textContent='Delete'; del.onclick = ()=> deleteFrame(f);
-    right.appendChild(edit); right.appendChild(del);
-    item.appendChild(left); item.appendChild(right);
-    el.appendChild(item);
-  });
-}
-function renderDoors(doors = []) {
-  const el = document.getElementById('doorsList');
-  el.innerHTML = '';
-  (doors || []).forEach((d, idx) => {
-    const item = document.createElement('div');
-    item.className = 'item';
-    const left = document.createElement('div');
-    left.innerHTML = `<strong>Door ${idx+1}</strong><div class="muted">${Object.entries(d.data || d).slice(0,2).map(kv=>kv.join(': ')).join(' — ')}</div>`;
-    const right = document.createElement('div');
-    const edit = document.createElement('button'); edit.textContent='Edit'; edit.onclick = ()=> openModalForEdit('door', d, idx);
-    const del = document.createElement('button'); del.textContent='Delete'; del.onclick = ()=> deleteDoor(d);
-    right.appendChild(edit); right.appendChild(del);
+    const btn = document.createElement('button'); btn.textContent = 'Open';
+    btn.onclick = () => { selectedWorkOrderId = wo.id; renderEntries(wo.entries); };
+    right.appendChild(btn);
     item.appendChild(left); item.appendChild(right);
     el.appendChild(item);
   });
 }
 
-/* delete individual frame/door via server delete not implemented in server code above,
-   so easiest approach: re-load job from server after deleting on server (you can add delete endpoints later).
-   For now, we will warn and instruct user to use SQL or add endpoints. */
-async function deleteFrame(frameRec) {
-  if (!confirm('Delete this frame?')) return;
-  const r = await api('/frames/' + frameRec.id, { method: 'DELETE' });
-  if (!r.ok) return alert('Delete failed');
-  const jobId = document.getElementById('jobId').value;
-  if (jobId) {
-    const jobRes = await api('/jobs/' + jobId);
-    if (jobRes.ok) {
-      loadedJob = jobRes.json;
-      renderFrames(loadedJob.frames);
+function renderEntries(entries = []) {
+  const el = document.getElementById('entriesList');
+  el.innerHTML = '';
+  (entries || []).forEach((en, idx) => {
+    const item = document.createElement('div');
+    item.className = 'item';
+    const left = document.createElement('div');
+    left.innerHTML = `<strong>Entry ${idx + 1} (${en.handing})</strong>`;
+    const details = document.createElement('div');
+    details.className = 'muted';
+    const frameInfo = en.frames && en.frames[0] ? Object.entries(en.frames[0].data || {}).slice(0,2).map(kv => kv.join(': ')).join(' — ') : '';
+    let doorInfo = '';
+    (en.doors || []).forEach(d => {
+      doorInfo += `Door ${d.leaf}: ${Object.entries(d.data || {}).slice(0,2).map(kv => kv.join(': ')).join(' — ')}<br/>`;
+    });
+    details.innerHTML = `<div>Frame: ${frameInfo || '(no data)'}</div><div>${doorInfo}</div>`;
+    left.appendChild(details);
+    const right = document.createElement('div');
+    if (en.frames && en.frames[0]) {
+      const ef = document.createElement('button'); ef.textContent = 'Edit Frame'; ef.onclick = () => openModalForEdit('frame', en.frames[0]); right.appendChild(ef);
     }
-  }
-}
-async function deleteDoor(doorRec) {
-  if (!confirm('Delete this door?')) return;
-  const r = await api('/doors/' + doorRec.id, { method: 'DELETE' });
-  if (!r.ok) return alert('Delete failed');
-  const jobId = document.getElementById('jobId').value;
-  if (jobId) {
-    const jobRes = await api('/jobs/' + jobId);
-    if (jobRes.ok) {
-      loadedJob = jobRes.json;
-      renderDoors(loadedJob.doors);
-    }
-  }
+    (en.doors || []).forEach(d => {
+      const ed = document.createElement('button'); ed.textContent = `Edit Door ${d.leaf}`; ed.onclick = () => openModalForEdit('door', d); right.appendChild(ed);
+    });
+    item.appendChild(left); item.appendChild(right);
+    el.appendChild(item);
+  });
 }
 
-/* Modal to add/edit custom KV object */
+document.getElementById('addWorkOrder').addEventListener('click', async () => {
+  const jobId = document.getElementById('jobId').value;
+  const wo = document.getElementById('newWorkOrder').value.trim();
+  if (!jobId || !wo) return alert('Job and work order required');
+  const r = await api(`/jobs/${jobId}/work-orders`, { method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify({ workOrder: wo }) });
+  if (!r.ok) return alert('Failed to add work order');
+  document.getElementById('newWorkOrder').value = '';
+  const jobRes = await api('/jobs/' + jobId);
+  if (jobRes.ok) {
+    loadedJob = jobRes.json;
+    renderWorkOrders(loadedJob.workOrders);
+  }
+});
+
+document.getElementById('addEntry').addEventListener('click', async () => {
+  if (!selectedWorkOrderId) return alert('Select a work order first');
+  const handing = prompt('Handing (e.g. LHR, RHR, LHRA, RHRA):');
+  if (!handing) return;
+  const r = await api(`/work-orders/${selectedWorkOrderId}/entries`, { method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify({ handing, entryData: {}, frameData: {}, doorData: {} }) });
+  if (!r.ok) return alert('Failed to add entry');
+  const jobId = document.getElementById('jobId').value;
+  const jobRes = await api('/jobs/' + jobId);
+  if (jobRes.ok) {
+    loadedJob = jobRes.json;
+    renderWorkOrders(loadedJob.workOrders);
+    const wo = loadedJob.workOrders.find(w => w.id === selectedWorkOrderId);
+    if (wo) renderEntries(wo.entries);
+  }
+});
+
+// Modal for editing frame/door data
 const modal = document.getElementById('modal');
 const kvContainer = document.getElementById('kvContainer');
-let modalMode = null; // { kind: 'frame'|'door', data: {...}, record: serverRecord if editing }
-function openModal(kind) {
-  modalMode = { kind, data: {} };
-  kvContainer.innerHTML = '';
-  document.getElementById('modalTitle').textContent = 'Add ' + kind;
-  addKVrow('Location','');
-  addKVrow('Notes','');
-  modal.style.display = 'flex';
-}
-function openModalForEdit(kind, serverRec, idx) {
+let modalMode = null;
+function openModalForEdit(kind, serverRec) {
   modalMode = { kind, serverRec };
   kvContainer.innerHTML = '';
-  const data = serverRec.data || serverRec;
+  const data = serverRec.data || {};
+  Object.entries(data).forEach(([k, v]) => addKVrow(k, v));
   document.getElementById('modalTitle').textContent = 'Edit ' + kind;
-  Object.entries(data).forEach(([k,v]) => addKVrow(k, v));
   modal.style.display = 'flex';
 }
-function addKVrow(k='', v='') {
+function addKVrow(k = '', v = '') {
   const row = document.createElement('div');
   row.style.display = 'flex';
   row.style.gap = '8px';
   row.style.marginTop = '6px';
   const kInput = document.createElement('input'); kInput.placeholder = 'Field name'; kInput.value = k;
-  const vInput = document.createElement('input'); vInput.placeholder='Value'; vInput.value = v;
-  const rm = document.createElement('button'); rm.textContent='✖'; rm.onclick = ()=> row.remove();
+  const vInput = document.createElement('input'); vInput.placeholder = 'Value'; vInput.value = v;
+  const rm = document.createElement('button'); rm.textContent = '✖'; rm.onclick = () => row.remove();
   row.appendChild(kInput); row.appendChild(vInput); row.appendChild(rm);
   kvContainer.appendChild(row);
 }
-document.getElementById('addKVbtn').addEventListener('click', ()=> addKVrow());
-document.getElementById('modalCancel').addEventListener('click', ()=> { modal.style.display='none'; modalMode=null; });
+document.getElementById('addKVbtn').addEventListener('click', () => addKVrow());
+document.getElementById('modalCancel').addEventListener('click', () => { modal.style.display = 'none'; modalMode = null; });
 
-/* save modal -> POST to server for single insert */
-document.getElementById('modalSave').addEventListener('click', async ()=>{
+document.getElementById('modalSave').addEventListener('click', async () => {
   if (!modalMode) return;
-  const kind = modalMode.kind;
-  const jobId = document.getElementById('jobId').value;
-  if (!jobId) return alert('Job number required before adding items.');
   const fields = {};
   kvContainer.querySelectorAll('div').forEach(row => {
     const inputs = row.querySelectorAll('input');
     if (inputs[0].value.trim()) fields[inputs[0].value.trim()] = inputs[1].value;
   });
-
-  const endpoint = `/${kind === 'frame' ? 'jobs/'+jobId+'/frames' : 'jobs/'+jobId+'/doors'}`;
-  const r = await api(endpoint, { method: 'POST', headers:{'content-type':'application/json'}, body: JSON.stringify({ data: fields }) });
+  const endpoint = `/${modalMode.kind === 'frame' ? 'frames/' + modalMode.serverRec.id : 'doors/' + modalMode.serverRec.id}`;
+  const r = await api(endpoint, { method: 'PUT', headers: { 'content-type': 'application/json' }, body: JSON.stringify({ data: fields }) });
   if (!r.ok) return alert('Failed to save');
-  modal.style.display='none';
-  // reload job to refresh lists
-  const jobRes = await api('/jobs/' + jobId);
-  if (jobRes.ok) {
-    loadedJob = jobRes.json;
-    renderFrames(loadedJob.frames);
-    renderDoors(loadedJob.doors);
-  }
-});
-
-/* add frame/door buttons */
-document.getElementById('addFrame').addEventListener('click', ()=> openModal('frame'));
-document.getElementById('addDoor').addEventListener('click', ()=> openModal('door'));
-
-/* CSV import buttons - upload file to server */
-document.getElementById('importFramesBtn').addEventListener('click', async ()=>{
-  const fileInput = document.getElementById('framesCsv');
-  const file = fileInput.files[0];
+  modal.style.display = 'none'; modalMode = null;
   const jobId = document.getElementById('jobId').value;
-  if (!file) return alert('Select a CSV file');
-  if (!jobId) return alert('Enter or select job to import into.');
-  const fd = new FormData();
-  fd.append('file', file);
-  const resp = await fetch(API_BASE + '/api/jobs/' + jobId + '/import-frames', { method:'POST', body: fd });
-  const txt = await resp.text();
-  if (!resp.ok) return alert('Import failed: ' + txt);
-  alert('Frames imported');
-  // refresh loaded job
-  const jobRes = await api('/jobs/' + jobId);
-  if (jobRes.ok) {
-    loadedJob = jobRes.json;
-    renderFrames(loadedJob.frames);
+  if (jobId) {
+    const jobRes = await api('/jobs/' + jobId);
+    if (jobRes.ok) {
+      loadedJob = jobRes.json;
+      renderWorkOrders(loadedJob.workOrders);
+      if (selectedWorkOrderId) {
+        const wo = loadedJob.workOrders.find(w => w.id === selectedWorkOrderId);
+        if (wo) renderEntries(wo.entries);
+      }
+    }
   }
 });
 
-document.getElementById('importDoorsBtn').addEventListener('click', async ()=>{
-  const fileInput = document.getElementById('doorsCsv');
-  const file = fileInput.files[0];
-  const jobId = document.getElementById('jobId').value;
-  if (!file) return alert('Select a CSV file');
-  if (!jobId) return alert('Enter or select job to import into.');
-  const fd = new FormData();
-  fd.append('file', file);
-  const resp = await fetch(API_BASE + '/api/jobs/' + jobId + '/import-doors', { method:'POST', body: fd });
-  const txt = await resp.text();
-  if (!resp.ok) return alert('Import failed: ' + txt);
-  alert('Doors imported');
-  // refresh loaded job
-  const jobRes = await api('/jobs/' + jobId);
-  if (jobRes.ok) {
-    loadedJob = jobRes.json;
-    renderDoors(loadedJob.doors);
-  }
-});
-
-/* Export PDF: fetch job details then generate PDF using jsPDF
-   Page 1: Job info
-   Then one page per frame
-   Then one page per door
-*/
 async function exportJobToPDF(jobId) {
   const r = await api('/jobs/' + jobId);
   if (!r.ok) return alert('Failed to fetch job');
   const data = r.json;
   const job = data.job;
-  const frames = data.frames || [];
-  const doors = data.doors || [];
-
+  const frames = [];
+  const doors = [];
+  (data.workOrders || []).forEach(wo => {
+    (wo.entries || []).forEach(en => {
+      frames.push(...(en.frames || []));
+      doors.push(...(en.doors || []));
+    });
+  });
   const { jsPDF } = window.jspdf;
-  const doc = new jsPDF({unit:'pt', format:'letter'});
+  const doc = new jsPDF({ unit: 'pt', format: 'letter' });
   const margin = 36;
   const startY = 48;
-  const usableW = 612 - margin*2;
+  const usableW = 612 - margin * 2;
   const lineH = 14;
-
   function writeKeyVals(obj, title) {
     doc.setFontSize(16);
     doc.text(title, margin, startY);
@@ -300,59 +253,44 @@ async function exportJobToPDF(jobId) {
       if (y > 720) { doc.addPage(); y = startY; }
     }
   }
-
-  // Page 1 job info
   const jobInfo = {
     'Job Number': job.job_number || '',
     'Job Name': job.job_name || '',
-    'PM': job.pm || '',
-    'Work Order #': job.work_order || ''
+    'PM': job.pm || ''
   };
   writeKeyVals(jobInfo, 'Job Information');
-
-  // one page per frame
-  for (let i=0;i<frames.length;i++) {
+  for (let i = 0; i < frames.length; i++) {
     doc.addPage();
-    writeKeyVals(frames[i].data, `Frame ${i+1}`);
+    writeKeyVals(frames[i].data, `Frame ${i + 1}`);
   }
-
-  // one page per door
-  for (let i=0;i<doors.length;i++) {
+  for (let i = 0; i < doors.length; i++) {
     doc.addPage();
-    writeKeyVals(doors[i].data, `Door ${i+1}`);
+    writeKeyVals(doors[i].data, `Door ${i + 1}`);
   }
-
-  const filename = `Job_${job.job_number || 'no-number'}_${job.work_order || ''}.pdf`;
+  const filename = `Job_${job.job_number || 'no-number'}.pdf`;
   doc.save(filename);
 }
 
-document.getElementById('exportPdfSelected').addEventListener('click', async ()=>{
+document.getElementById('exportPdfSelected').addEventListener('click', async () => {
   const sel = document.getElementById('jobsSelect');
   if (!sel.value) return alert('Select a job first');
   exportJobToPDF(sel.value);
 });
 
-/* Download all jobs raw JSON (convenience) */
-document.getElementById('exportJsonDownload').addEventListener('click', async ()=>{
+document.getElementById('exportJsonDownload').addEventListener('click', async () => {
   const r = await api('/jobs?includeArchived=true');
   if (!r.ok) return alert('Failed');
   const json = r.json;
-  // For simplicity fetch each job details
   const promises = json.jobs.map(j => api('/jobs/' + j.id));
   const results = await Promise.all(promises);
   const aggregated = {};
-  results.forEach(res => {
-    if (res.ok && res.json && res.json.job) {
-      aggregated[res.json.job.id] = res.json;
-    }
-  });
+  results.forEach(res => { if (res.ok && res.json && res.json.job) aggregated[res.json.job.id] = res.json; });
   const blob = new Blob([JSON.stringify(aggregated, null, 2)], { type: 'application/json' });
   const url = URL.createObjectURL(blob);
   const a = document.createElement('a'); a.href = url; a.download = 'jobs_all.json'; a.click();
   URL.revokeObjectURL(url);
 });
 
-/* init */
 refreshJobList('', viewArchivedEl.checked);
 
 const darkBtn = document.getElementById('toggleDarkMode');


### PR DESCRIPTION
## Summary
- Add API routes to update frame and door records
- Replace job-level frame/door UI with work order and entry management
- Allow editing frame and door data within each entry

## Testing
- `npm test --prefix backend` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689e6e3a2ff883299ca9a83ce5624a77