### PR TITLE
Highlight active work order and enable entry editing

### DIFF
--- a/backend/src/routes.js
+++ b/backend/src/routes.js
@@ -121,6 +121,22 @@ router.post('/work-orders/:id/entries', async (req, res) => {
   }
 });
 
+// Update entry handing or data
+router.put('/entries/:id', async (req, res) => {
+  const id = req.params.id;
+  const { handing, data } = req.body;
+  try {
+    const result = await pool.query(
+      'UPDATE entries SET handing = $1, data = $2 WHERE id = $3 RETURNING *',
+      [handing, data, id]
+    );
+    if (result.rowCount === 0) return res.status(404).json({ error: 'Entry not found' });
+    res.json({ entry: result.rows[0] });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
 // Delete frame
 router.delete('/frames/:id', async (req, res) => {
   const id = req.params.id;

--- a/frontend/css/style.css
+++ b/frontend/css/style.css
@@ -212,3 +212,15 @@ body.dark button:focus {
   text-align: right;
 }
 
+#workOrdersList .item.active {
+  background-color: var(--vos-red);
+  color: var(--vos-white);
+}
+#workOrdersList .item.active button {
+  background-color: var(--vos-white);
+  color: var(--vos-red);
+}
+#workOrdersList .item.inactive {
+  opacity: 0.5;
+}
+


### PR DESCRIPTION
## Summary
- Highlight the currently active work order and dim inactive ones for clarity
- Allow entry tag, handing, width, and height to be edited after creation
- Support entry updates via new backend endpoint

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689e747f2ecc8329b1959b0a083ce796