### PR TITLE
fix: correct dark mode modal background

### DIFF
--- a/frontend/css/style.css
+++ b/frontend/css/style.css
@@ -199,7 +199,7 @@ body.dark button:focus {
 }
 
 .modal-body {
-  background: white;
+  background: var(--vos-white);
   padding: 16px;
   border-radius: 6px;
   width: 600px;
@@ -207,13 +207,9 @@ body.dark button:focus {
   overflow: auto;
 }
 
-.modal-body.dark {
-  background: var(--vos-dark);
-  padding: 16px;
-  border-radius: 6px;
-  width: 600px;
-  max-height: 80vh;
-  overflow: auto;
+body.dark .modal-body {
+  background: #333;
+  color: var(--vos-gray);
 }
 
 .modal-actions {


### PR DESCRIPTION
## Summary
- ensure modal backgrounds respond to dark mode

## Testing
- `npm test` (fails: Missing script "test")


------
https://chatgpt.com/codex/tasks/task_e_689e835581d4832992aa8a2e3a0a617b