### PR TITLE
Handle legacy entryData when updating entries

### DIFF
--- a/backend/src/routes.js
+++ b/backend/src/routes.js
@@ -124,11 +124,13 @@ router.post('/work-orders/:id/entries', async (req, res) => {
 // Update entry handing or data
 router.put('/entries/:id', async (req, res) => {
   const id = req.params.id;
-  const { handing, data } = req.body;
+  const { handing, data, entryData } = req.body;
+  // Some clients may still send entryData instead of data – fall back if needed
+  const updatedData = data !== undefined ? data : entryData;
   try {
     const result = await pool.query(
       'UPDATE entries SET handing = $1, data = $2 WHERE id = $3 RETURNING *',
-      [handing, data, id]
+      [handing, updatedData, id]
     );
     if (result.rowCount === 0) return res.status(404).json({ error: 'Entry not found' });
     res.json({ entry: result.rows[0] });


### PR DESCRIPTION
## Summary
- allow `/entries/:id` PUT handler to accept either `data` or `entryData` payloads

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689e8d03d67083298b5883e7ce16c935