### PR TITLE
Add entry update route tests

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -4,7 +4,8 @@
   "description": "Backend API for Job Tracker",
   "main": "src/server.js",
   "scripts": {
-    "start": "node src/server.js"
+    "start": "node src/server.js",
+    "test": "jest"
   },
   "dependencies": {
     "cors": "^2.8.5",
@@ -12,5 +13,11 @@
     "express": "^4.18.2",
     "pg": "^8.10.0",
     "multer": "^2.0.2"
+  },
+  "devDependencies": {
+    "jest": "^29.7.0",
+    "supertest": "^6.3.3",
+    "@types/jest": "^29.5.11",
+    "@types/supertest": "^2.0.12"
   }
 }

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -8,5 +8,9 @@ app.use(cors());
 app.use(express.json());
 app.use('/api', routes);
 
-const PORT = process.env.PORT || 3000;
-app.listen(PORT, () => console.log(`Backend running on port ${PORT}`));
+if (require.main === module) {
+  const PORT = process.env.PORT || 3000;
+  app.listen(PORT, () => console.log(`Backend running on port ${PORT}`));
+}
+
+module.exports = app;

--- a/backend/tests/entry-update.test.js
+++ b/backend/tests/entry-update.test.js
@@ -1,0 +1,64 @@
+const request = require('supertest');
+const app = require('../src/server');
+const pool = require('../src/db');
+
+jest.mock('../src/db');
+
+describe('PUT /api/entries/:id', () => {
+  let client;
+  beforeEach(() => {
+    client = {
+      query: jest.fn(),
+      release: jest.fn(),
+    };
+    pool.connect.mockResolvedValue(client);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('adds B leaf when updating from single to double handing', async () => {
+    client.query
+      .mockResolvedValueOnce({}) // BEGIN
+      .mockResolvedValueOnce({ rows: [{ handing: 'RHR' }], rowCount: 1 }) // SELECT handing
+      .mockResolvedValueOnce({}) // UPDATE entries
+      .mockResolvedValueOnce({ rows: [{ data: { foo: 'bar' } }] }) // SELECT door data
+      .mockResolvedValueOnce({}) // INSERT B leaf
+      .mockResolvedValueOnce({}) // COMMIT
+      .mockResolvedValueOnce({ rows: [{ id: 1, handing: 'RHRA', data: 'new' }] }); // SELECT updated
+
+    const res = await request(app)
+      .put('/api/entries/1')
+      .send({ handing: 'RHRA', data: 'new' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.entry).toEqual({ id: 1, handing: 'RHRA', data: 'new' });
+    expect(client.query).toHaveBeenCalledWith(
+      "INSERT INTO doors (entry_id, leaf, data) VALUES ($1, 'B', $2)",
+      ['1', { foo: 'bar' }]
+    );
+  });
+
+  test('removes B leaf when updating from double to single handing', async () => {
+    client.query
+      .mockResolvedValueOnce({}) // BEGIN
+      .mockResolvedValueOnce({ rows: [{ handing: 'RHRA' }], rowCount: 1 }) // SELECT handing
+      .mockResolvedValueOnce({}) // UPDATE entries
+      .mockResolvedValueOnce({}) // DELETE B leaf
+      .mockResolvedValueOnce({}) // COMMIT
+      .mockResolvedValueOnce({ rows: [{ id: 1, handing: 'RHR', data: 'new' }] }); // SELECT updated
+
+    const res = await request(app)
+      .put('/api/entries/1')
+      .send({ handing: 'RHR', data: 'new' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.entry).toEqual({ id: 1, handing: 'RHR', data: 'new' });
+    expect(client.query).toHaveBeenCalledWith(
+      "DELETE FROM doors WHERE entry_id = $1 AND leaf = 'B'",
+      ['1']
+    );
+  });
+});
+


### PR DESCRIPTION
## Summary
- add Jest and Supertest to backend dev dependencies and test script
- export Express app for testing
- add entry update route tests for leaf handling

## Testing
- `npm test` *(fails: sh: 1: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_689e90cb0c7c8329b60d2c079f0b3365