### PR TITLE
Use dropdown for project manager

### DIFF
--- a/frontend/data/project-managers.json
+++ b/frontend/data/project-managers.json
@@ -1,0 +1,5 @@
+[
+  "Alice Johnson",
+  "Bob Smith",
+  "Carol Williams"
+]

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -25,7 +25,7 @@
       <label>Job Name</label>
       <input id="jobName" type="text" />
       <label>PM</label>
-      <input id="pm" type="text" />
+      <select id="pm"></select>
       <label class="checkbox"><input id="archived" type="checkbox" /> Archived</label>
       <div class="action-buttons">
         <button id="saveJob">Save Job</button>

--- a/frontend/js/app.js
+++ b/frontend/js/app.js
@@ -10,6 +10,27 @@ let loadedJob = null;
 let selectedWorkOrderId = null;
 let editingEntry = null;
 
+let projectManagers = [];
+
+async function loadProjectManagers() {
+  try {
+    const res = await fetch('data/project-managers.json');
+    projectManagers = await res.json();
+    const pmSelect = document.getElementById('pm');
+    pmSelect.innerHTML = '<option value=""></option>';
+    projectManagers.forEach(pm => {
+      const opt = document.createElement('option');
+      opt.value = pm;
+      opt.textContent = pm;
+      pmSelect.appendChild(opt);
+    });
+  } catch (err) {
+    console.error('Failed to load project managers', err);
+  }
+}
+
+loadProjectManagers();
+
 async function refreshJobList(filter = '', includeArchived = false) {
   const { json } = await api('/jobs?includeArchived=' + includeArchived);
   const sel = document.getElementById('jobsSelect');
@@ -58,7 +79,15 @@ document.getElementById('loadSelected').addEventListener('click', async () => {
   document.getElementById('jobId').value = data.job.id;
   document.getElementById('jobNumber').value = data.job.job_number || '';
   document.getElementById('jobName').value = data.job.job_name || '';
-  document.getElementById('pm').value = data.job.pm || '';
+  const pmSelect = document.getElementById('pm');
+  const pmValue = data.job.pm || '';
+  if (!Array.from(pmSelect.options).some(o => o.value === pmValue)) {
+    const opt = document.createElement('option');
+    opt.value = pmValue;
+    opt.textContent = pmValue;
+    pmSelect.appendChild(opt);
+  }
+  pmSelect.value = pmValue;
   document.getElementById('archived').checked = !!data.job.archived;
   renderWorkOrders(data.workOrders);
   renderEntries([]);


### PR DESCRIPTION
## Summary
- replace free-text PM field with a select box populated from a JSON list of project managers
- load list of project managers on page start and ensure existing job PM values are selectable

## Testing
- `npm test` *(fails: Jest encountered an unexpected token in backend/src/routes.js)*

------
https://chatgpt.com/codex/tasks/task_e_689fe3f2feac8329a970066dd60dad22