### PR TITLE
Refine entry data editing and PDF export

### DIFF
--- a/backend/src/routes.js
+++ b/backend/src/routes.js
@@ -194,16 +194,6 @@ router.delete('/doors/:id', async (req, res) => {
   } catch (err) {
     res.status(500).json({ error: err.message });
   }
-// Delete door
-router.delete('/doors/:id', async (req, res) => {
-  const id = req.params.id;
-  try {
-    const result = await pool.query('DELETE FROM doors WHERE id = $1', [id]);
-    if (result.rowCount === 0) return res.status(404).json({ error: 'Door not found' });
-    res.json({ message: 'Door deleted' });
-  } catch (err) {
-    res.status(500).json({ error: err.message });
-  }
 });
 
 // Update frame data


### PR DESCRIPTION
## Summary
- Hide standard entry fields in the entry data modal and preserve them on save while allowing custom fields
- Include entry-level variables on frame and door PDF pages above part details
- Remove duplicate door delete route in backend

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689fe963833483299de184b3460efc91