### PR TITLE
feat: add entry global settings tab

### DIFF
--- a/frontend/css/style.css
+++ b/frontend/css/style.css
@@ -236,6 +236,33 @@ body.dark button:focus {
   overflow: auto;
 }
 
+#modalTabs {
+  display: none;
+  gap: 8px;
+  margin-top: 8px;
+}
+
+#modalTabs button {
+  flex: 1;
+  margin-top: 0;
+  background: var(--vos-gray);
+  color: var(--vos-dark);
+}
+
+#modalTabs button.active {
+  background: var(--vos-red);
+  color: var(--vos-white);
+}
+
+.tab-content {
+  display: none;
+  margin-top: 8px;
+}
+
+.tab-content.active {
+  display: block;
+}
+
 body.dark .modal-body {
   background: #333;
   color: var(--vos-gray);

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -109,8 +109,24 @@
 <div id="modal" class="modal-overlay">
   <div class="modal-body">
     <h3 id="modalTitle">Add Item</h3>
-    <div id="kvContainer"></div>
-    <button id="addKVbtn">Add field</button>
+    <div id="modalTabs" class="tabs">
+      <button id="formulaTabBtn" class="active" data-tab="formula">Formula</button>
+      <button id="globalTabBtn" data-tab="global">Global Settings</button>
+    </div>
+    <div id="formulaTab" class="tab-content">
+      <div id="kvContainer"></div>
+      <button id="addKVbtn">Add field</button>
+    </div>
+    <div id="globalTab" class="tab-content">
+      <label for="topGapInput">Top Gap</label>
+      <input id="topGapInput" type="number" step="any" />
+      <label for="bottomGapInput">Bottom Gap</label>
+      <input id="bottomGapInput" type="number" step="any" />
+      <label for="hingeGapInput">Hinge Gap</label>
+      <input id="hingeGapInput" type="number" step="any" />
+      <label for="strikeGapInput">Strike Gap</label>
+      <input id="strikeGapInput" type="number" step="any" />
+    </div>
     <div class="modal-actions">
       <button id="modalSave">Save</button>
       <button id="modalCancel">Cancel</button>

--- a/frontend/js/app.js
+++ b/frontend/js/app.js
@@ -12,6 +12,13 @@ let editingEntry = null;
 
 let projectManagers = [];
 
+const DEFAULT_GLOBALS = {
+  topGap: '.125',
+  bottomGap: '.6875',
+  hingeGap: '.0625',
+  strikeGap: '.125'
+};
+
 async function loadProjectManagers() {
   try {
     const res = await fetch('data/project-managers.json');
@@ -281,15 +288,43 @@ function openPartsModal(entry) {
 // Modal for editing entry/frame/door data
 const modal = document.getElementById('modal');
 const kvContainer = document.getElementById('kvContainer');
+const modalTabs = document.getElementById('modalTabs');
+const formulaTabBtn = document.getElementById('formulaTabBtn');
+const globalTabBtn = document.getElementById('globalTabBtn');
+const formulaTab = document.getElementById('formulaTab');
+const globalTab = document.getElementById('globalTab');
+const topGapInput = document.getElementById('topGapInput');
+const bottomGapInput = document.getElementById('bottomGapInput');
+const hingeGapInput = document.getElementById('hingeGapInput');
+const strikeGapInput = document.getElementById('strikeGapInput');
 let modalMode = null;
+
+function showModalTab(tab) {
+  formulaTab.classList.toggle('active', tab === 'formula');
+  globalTab.classList.toggle('active', tab === 'global');
+  formulaTabBtn.classList.toggle('active', tab === 'formula');
+  globalTabBtn.classList.toggle('active', tab === 'global');
+}
+
+formulaTabBtn.addEventListener('click', () => showModalTab('formula'));
+globalTabBtn.addEventListener('click', () => showModalTab('global'));
 function openModalForEdit(kind, serverRec) {
   modalMode = { kind, serverRec };
   kvContainer.innerHTML = '';
   const data = serverRec.data || {};
   let entries = Object.entries(data);
   if (kind === 'entry') {
-    const excluded = ['tag', 'openingWidth', 'openingHeight'];
+    const excluded = ['tag', 'openingWidth', 'openingHeight', 'topGap', 'bottomGap', 'hingeGap', 'strikeGap'];
     entries = entries.filter(([k]) => !excluded.includes(k));
+    topGapInput.value = data.topGap !== undefined ? data.topGap : DEFAULT_GLOBALS.topGap;
+    bottomGapInput.value = data.bottomGap !== undefined ? data.bottomGap : DEFAULT_GLOBALS.bottomGap;
+    hingeGapInput.value = data.hingeGap !== undefined ? data.hingeGap : DEFAULT_GLOBALS.hingeGap;
+    strikeGapInput.value = data.strikeGap !== undefined ? data.strikeGap : DEFAULT_GLOBALS.strikeGap;
+    modalTabs.style.display = 'flex';
+    showModalTab('formula');
+  } else {
+    modalTabs.style.display = 'none';
+    showModalTab('formula');
   }
   entries.forEach(([k, v]) => addKVrow(k, v));
   document.getElementById('modalTitle').textContent = 'Edit ' + kind.charAt(0).toUpperCase() + kind.slice(1);
@@ -327,12 +362,16 @@ document.getElementById('modalSave').addEventListener('click', async () => {
   } else if (modalMode.kind === 'entry') {
     endpoint = `/entries/${modalMode.serverRec.id}`;
     const original = modalMode.serverRec.data || {};
-    const preservedKeys = ['tag', 'openingWidth', 'openingHeight'];
+    const preservedKeys = ['tag', 'openingWidth', 'openingHeight', 'topGap', 'bottomGap', 'hingeGap', 'strikeGap'];
     const preserved = {};
     preservedKeys.forEach(k => {
       if (original[k] !== undefined) preserved[k] = original[k];
     });
     const data = { ...preserved };
+    data.topGap = topGapInput.value || DEFAULT_GLOBALS.topGap;
+    data.bottomGap = bottomGapInput.value || DEFAULT_GLOBALS.bottomGap;
+    data.hingeGap = hingeGapInput.value || DEFAULT_GLOBALS.hingeGap;
+    data.strikeGap = strikeGapInput.value || DEFAULT_GLOBALS.strikeGap;
     Object.keys(fields).forEach(k => { data[k] = fields[k]; });
     payload = { handing: modalMode.serverRec.handing, data };
   }


### PR DESCRIPTION
## Summary
- add tabbed modal for editing entry data and global gap settings
- store default gap settings and include them when saving entries
- style and wire up tabs for formula vs global settings

## Testing
- `cd backend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_689ff25a840083298ab324c01caed9ff