### PR TITLE
Add parts database and rail dropdowns

### DIFF
--- a/backend/migrations.sql
+++ b/backend/migrations.sql
@@ -77,3 +77,11 @@ CREATE TABLE IF NOT EXISTS door_parts (
     data JSONB
 );
 
+-- Parts available for rails
+CREATE TABLE IF NOT EXISTS parts (
+    id SERIAL PRIMARY KEY,
+    number VARCHAR(50) UNIQUE,
+    description TEXT,
+    usages TEXT[],
+    requires TEXT[]
+);

--- a/backend/tests/door-parts.test.js
+++ b/backend/tests/door-parts.test.js
@@ -22,14 +22,14 @@ describe('Door Parts API', () => {
     pool.query.mockResolvedValueOnce({ rows: [part] });
 
     const res = await request(app)
-      .post('/api/door-parts')
-      .send({ doorId: 1, partType: 'hinge', partLz: 1.25, partLy: 2.5, data: { foo: 'bar' } });
+      .post('/api/doors/1/parts')
+      .send({ partType: 'hinge', partLz: 1.25, partLy: 2.5, data: { foo: 'bar' } });
 
     expect(res.status).toBe(200);
     expect(res.body.part).toEqual(part);
     expect(pool.query).toHaveBeenCalledWith(
       'INSERT INTO door_parts (door_id, part_type, part_lz, part_ly, data) VALUES ($1, $2, $3, $4, $5) RETURNING *',
-      [1, 'hinge', 1.25, 2.5, { foo: 'bar' }]
+      ['1', 'hinge', 1.25, 2.5, { foo: 'bar' }]
     );
   });
 

--- a/backend/tests/parts.test.js
+++ b/backend/tests/parts.test.js
@@ -1,0 +1,63 @@
+const request = require('supertest');
+const app = require('../src/server');
+const pool = require('../src/db');
+
+jest.mock('../src/db');
+
+describe('Parts API', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('lists parts filtered by usage', async () => {
+    pool.query.mockResolvedValueOnce({ rows: [{ id: 1, number: 'E0086', usages: ['topRail', 'bottomRail'], requires: null }] });
+
+    const res = await request(app).get('/api/parts?usage=topRail');
+
+    expect(res.status).toBe(200);
+    expect(res.body.parts).toEqual([{ id: 1, number: 'E0086', usages: ['topRail', 'bottomRail'], requires: null }]);
+    expect(pool.query).toHaveBeenCalledWith('SELECT * FROM parts WHERE $1 = ANY(usages) ORDER BY number', ['topRail']);
+  });
+
+  test('adds a part', async () => {
+    const part = { id: 1, number: 'E0057', description: null, usages: ['hingeRail'], requires: [] };
+    pool.query.mockResolvedValueOnce({ rows: [part] });
+
+    const res = await request(app)
+      .post('/api/parts')
+      .send({ number: 'E0057', description: null, usages: ['hingeRail'], requires: [] });
+
+    expect(res.status).toBe(200);
+    expect(res.body.part).toEqual(part);
+    expect(pool.query).toHaveBeenCalledWith(
+      'INSERT INTO parts (number, description, usages, requires) VALUES ($1, $2, $3, $4) RETURNING *',
+      ['E0057', null, ['hingeRail'], []]
+    );
+  });
+
+  test('updates a part', async () => {
+    const part = { id: 1, number: 'E0057', description: '', usages: ['hingeRail'], requires: [] };
+    pool.query.mockResolvedValueOnce({ rows: [part], rowCount: 1 });
+
+    const res = await request(app)
+      .put('/api/parts/1')
+      .send({ number: 'E0057', description: '', usages: ['hingeRail'], requires: [] });
+
+    expect(res.status).toBe(200);
+    expect(res.body.part).toEqual(part);
+    expect(pool.query).toHaveBeenCalledWith(
+      'UPDATE parts SET number = $1, description = $2, usages = $3, requires = $4 WHERE id = $5 RETURNING *',
+      ['E0057', '', ['hingeRail'], [], '1']
+    );
+  });
+
+  test('deletes a part', async () => {
+    pool.query.mockResolvedValueOnce({ rowCount: 1 });
+
+    const res = await request(app).delete('/api/parts/1');
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ message: 'Part deleted' });
+    expect(pool.query).toHaveBeenCalledWith('DELETE FROM parts WHERE id = $1', ['1']);
+  });
+});

--- a/backend/tests/templates.test.js
+++ b/backend/tests/templates.test.js
@@ -4,7 +4,7 @@ const pool = require('../src/db');
 
 jest.mock('../src/db');
 
-describe('GET /api/templates', () => {
+describe('GET /api/door-part-templates', () => {
   afterEach(() => {
     jest.clearAllMocks();
   });
@@ -12,10 +12,10 @@ describe('GET /api/templates', () => {
   test('retrieves templates from the database', async () => {
     pool.query.mockResolvedValueOnce({ rows: [{ id: 1, name: 'Template A', parts: { foo: 'bar' } }] });
 
-    const res = await request(app).get('/api/templates');
+    const res = await request(app).get('/api/door-part-templates');
 
     expect(res.status).toBe(200);
     expect(res.body.templates).toEqual([{ id: 1, name: 'Template A', parts: { foo: 'bar' } }]);
-    expect(pool.query).toHaveBeenCalledWith('SELECT * FROM door_part_templates');
+    expect(pool.query).toHaveBeenCalledWith('SELECT * FROM door_part_templates ORDER BY id');
   });
 });

--- a/frontend/data.html
+++ b/frontend/data.html
@@ -29,6 +29,33 @@
   </div>
 
   <div class="panel">
+    <h2>Parts</h2>
+    <div id="partList" class="list"></div>
+    <label for="newPartNumber">Part Number</label>
+    <input id="newPartNumber" type="text" />
+    <div>
+      <p><strong>Door Parts</strong></p>
+      <label class="checkbox"><input id="newUsageTop" type="checkbox" /> Top Rail</label>
+      <label class="checkbox"><input id="newUsageBottom" type="checkbox" /> Bottom Rail</label>
+      <label class="checkbox"><input id="newUsageHinge" type="checkbox" /> Hinge Rail</label>
+      <label class="checkbox"><input id="newUsageLock" type="checkbox" /> Lock Rail</label>
+      <label class="checkbox"><input id="newUsageMid" type="checkbox" /> Mid Rail</label>
+      <label class="checkbox"><input id="newUsageGlass" type="checkbox" /> Glass Stop</label>
+      <label class="checkbox"><input id="newUsageDoorBacker" type="checkbox" /> Backer</label>
+      <p><strong>Frame Parts</strong></p>
+      <label class="checkbox"><input id="newUsageHingeJamb" type="checkbox" /> Hinge Jamb</label>
+      <label class="checkbox"><input id="newUsageLockJamb" type="checkbox" /> Lock Jamb</label>
+      <label class="checkbox"><input id="newUsageDoorHeader" type="checkbox" /> Door Header</label>
+      <label class="checkbox"><input id="newUsageTransomHeader" type="checkbox" /> Transom Header</label>
+      <label class="checkbox"><input id="newUsageDoorStop" type="checkbox" /> Door Stop</label>
+      <label class="checkbox"><input id="newUsageFrameBacker" type="checkbox" /> Backer</label>
+    </div>
+    <label for="newPartRequires">Requires (comma-separated)</label>
+    <input id="newPartRequires" type="text" />
+    <button id="addPart">Add Part</button>
+  </div>
+
+  <div class="panel">
     <h2>Frame Parts</h2>
     <p class="muted">Coming soon...</p>
   </div>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -132,14 +132,14 @@
       <div id="partsTab" class="tab-content">
         <label for="doorPartPreset">Door Preset</label>
         <select id="doorPartPreset"></select>
-        <label for="topRailInput">Top Rail</label>
-        <input id="topRailInput" type="text" />
-        <label for="bottomRailInput">Bottom Rail</label>
-        <input id="bottomRailInput" type="text" />
-        <label for="hingeRailInput">Hinge Rail</label>
-        <input id="hingeRailInput" type="text" />
-        <label for="latchRailInput">Latch Rail</label>
-        <input id="latchRailInput" type="text" />
+        <label for="topRailSelect">Top Rail</label>
+        <select id="topRailSelect"></select>
+        <label for="bottomRailSelect">Bottom Rail</label>
+        <select id="bottomRailSelect"></select>
+        <label for="hingeRailSelect">Hinge Rail</label>
+        <select id="hingeRailSelect"></select>
+        <label for="lockRailSelect">Lock Rail</label>
+        <select id="lockRailSelect"></select>
       </div>
     <div class="modal-actions">
       <button id="modalSave">Save</button>

--- a/frontend/js/data.js
+++ b/frontend/js/data.js
@@ -100,3 +100,82 @@ document.getElementById('addTemplate').onclick = async () => {
 
 loadProjectManagers();
 loadTemplates();
+loadParts();
+
+async function loadParts() {
+  const res = await api('/parts');
+  if (res.ok) renderParts(res.json.parts || []);
+}
+
+function renderParts(parts) {
+  const list = document.getElementById('partList');
+  list.innerHTML = '';
+  (parts || []).forEach(p => {
+    const item = document.createElement('div');
+    item.className = 'item';
+    const left = document.createElement('div');
+    const usages = (p.usages || []).join(', ');
+    const req = (p.requires && p.requires.length) ? ` (requires ${p.requires.join(', ')})` : '';
+    left.innerHTML = `<strong>${p.number}</strong> — ${usages}${req}`;
+    const right = document.createElement('div');
+    const edit = document.createElement('button');
+    edit.textContent = 'Edit';
+    edit.onclick = () => {
+      const number = prompt('Part number', p.number);
+      if (number === null) return;
+      const usagesStr = prompt('Usages (comma-separated topRail,bottomRail,hingeRail,lockRail,midRail,glassStop,doorBacker,hingeJamb,lockJamb,doorHeader,transomHeader,doorStop,frameBacker)', (p.usages || []).join(','));
+      if (usagesStr === null) return;
+      const requiresStr = prompt('Requires (comma-separated part numbers)', (p.requires || []).join(','));
+      const usages = usagesStr.split(',').map(s => s.trim()).filter(Boolean);
+      const requires = requiresStr.split(',').map(s => s.trim()).filter(Boolean);
+      api(`/parts/${p.id}`, { method: 'PUT', headers: { 'content-type': 'application/json' }, body: JSON.stringify({ number, usages, requires }) }).then(loadParts);
+    };
+    const del = document.createElement('button');
+    del.textContent = 'Delete';
+    del.onclick = () => {
+      if (!confirm('Delete part ' + p.number + '?')) return;
+      api(`/parts/${p.id}`, { method: 'DELETE' }).then(loadParts);
+    };
+    right.appendChild(edit); right.appendChild(del);
+    item.appendChild(left); item.appendChild(right);
+    list.appendChild(item);
+  });
+}
+
+document.getElementById('addPart').onclick = async () => {
+  const number = document.getElementById('newPartNumber').value.trim();
+  if (!number) return;
+  const usages = [];
+  if (document.getElementById('newUsageTop').checked) usages.push('topRail');
+  if (document.getElementById('newUsageBottom').checked) usages.push('bottomRail');
+  if (document.getElementById('newUsageHinge').checked) usages.push('hingeRail');
+  if (document.getElementById('newUsageLock').checked) usages.push('lockRail');
+  if (document.getElementById('newUsageMid').checked) usages.push('midRail');
+  if (document.getElementById('newUsageGlass').checked) usages.push('glassStop');
+  if (document.getElementById('newUsageDoorBacker').checked) usages.push('doorBacker');
+  if (document.getElementById('newUsageHingeJamb').checked) usages.push('hingeJamb');
+  if (document.getElementById('newUsageLockJamb').checked) usages.push('lockJamb');
+  if (document.getElementById('newUsageDoorHeader').checked) usages.push('doorHeader');
+  if (document.getElementById('newUsageTransomHeader').checked) usages.push('transomHeader');
+  if (document.getElementById('newUsageDoorStop').checked) usages.push('doorStop');
+  if (document.getElementById('newUsageFrameBacker').checked) usages.push('frameBacker');
+  const reqStr = document.getElementById('newPartRequires').value.trim();
+  const requires = reqStr ? reqStr.split(',').map(s => s.trim()).filter(Boolean) : [];
+  await api('/parts', { method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify({ number, usages, requires }) });
+  document.getElementById('newPartNumber').value = '';
+  document.getElementById('newUsageTop').checked = false;
+  document.getElementById('newUsageBottom').checked = false;
+  document.getElementById('newUsageHinge').checked = false;
+  document.getElementById('newUsageLock').checked = false;
+  document.getElementById('newUsageMid').checked = false;
+  document.getElementById('newUsageGlass').checked = false;
+  document.getElementById('newUsageDoorBacker').checked = false;
+  document.getElementById('newUsageHingeJamb').checked = false;
+  document.getElementById('newUsageLockJamb').checked = false;
+  document.getElementById('newUsageDoorHeader').checked = false;
+  document.getElementById('newUsageTransomHeader').checked = false;
+  document.getElementById('newUsageDoorStop').checked = false;
+  document.getElementById('newUsageFrameBacker').checked = false;
+  document.getElementById('newPartRequires').value = '';
+  loadParts();
+};

--- a/frontend/js/doorPartPresets.js
+++ b/frontend/js/doorPartPresets.js
@@ -5,6 +5,6 @@ const DOOR_PART_PRESETS = [
     topRail: 'TR-001',
     bottomRail: 'BR-001',
     hingeRail: 'HR-001',
-    latchRail: 'LR-001'
+    lockRail: 'LR-001'
   }
 ];


### PR DESCRIPTION
## Summary
- add persistent `parts` table with CRUD API
- manage parts from data console and reference them in door part presets
- switch door rail inputs to dropdowns and capture required parts
- group door/frame usage options in management UI and add midrail, glass stop, jamb, header, stop, and backer selections

## Testing
- `npm test --prefix backend`


------
https://chatgpt.com/codex/tasks/task_e_68a0dd4db8508329b0525a3799cf2ba7