### PR TITLE
Enable door part templates to use existing parts

### DIFF
--- a/frontend/data.html
+++ b/frontend/data.html
@@ -21,8 +21,14 @@
     <div id="templateList" class="list"></div>
     <label for="newTemplateName">Template Name</label>
     <input id="newTemplateName" type="text" />
-    <label for="newTemplateParts">Parts (JSON)</label>
-    <textarea id="newTemplateParts"></textarea>
+    <label for="newTopRail">Top Rail</label>
+    <select id="newTopRail"></select>
+    <label for="newBottomRail">Bottom Rail</label>
+    <select id="newBottomRail"></select>
+    <label for="newHingeRail">Hinge Rail</label>
+    <select id="newHingeRail"></select>
+    <label for="newLockRail">Lock Rail</label>
+    <select id="newLockRail"></select>
     <button id="addTemplate">Add Template</button>
   </div>
 


### PR DESCRIPTION
## Summary
- Replace JSON textarea with drop-downs for selecting door rails in template creation
- Load parts from the database and populate rail selectors
- Build door part templates from selected rails and display parts in list

## Testing
- `cd backend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a0e7f0500c83298b8aef5373593f5e