### PR TITLE
Add dark mode slider and expand maintenance console

### DIFF
--- a/backend/migrations.sql
+++ b/backend/migrations.sql
@@ -82,6 +82,11 @@ CREATE TABLE IF NOT EXISTS parts (
     id SERIAL PRIMARY KEY,
     number VARCHAR(50) UNIQUE,
     description TEXT,
+    lx NUMERIC,
+    ly NUMERIC,
     usages TEXT[],
     requires TEXT[]
 );
+
+ALTER TABLE parts ADD COLUMN IF NOT EXISTS lx NUMERIC;
+ALTER TABLE parts ADD COLUMN IF NOT EXISTS ly NUMERIC;

--- a/backend/src/routes.js
+++ b/backend/src/routes.js
@@ -329,11 +329,11 @@ router.get('/parts', async (req, res) => {
 
 // Create a part
 router.post('/parts', async (req, res) => {
-  const { number, description, usages, requires } = req.body;
+  const { number, description, lx = null, ly = null, usages = [], requires = [] } = req.body;
   try {
     const result = await pool.query(
-      'INSERT INTO parts (number, description, usages, requires) VALUES ($1, $2, $3, $4) RETURNING *',
-      [number, description, usages, requires]
+      'INSERT INTO parts (number, description, lx, ly, usages, requires) VALUES ($1, $2, $3, $4, $5, $6) RETURNING *',
+      [number, description, lx, ly, usages, requires]
     );
     res.json({ part: result.rows[0] });
   } catch (err) {
@@ -344,11 +344,11 @@ router.post('/parts', async (req, res) => {
 // Update a part
 router.put('/parts/:id', async (req, res) => {
   const id = req.params.id;
-  const { number, description, usages, requires } = req.body;
+  const { number, description, lx = null, ly = null, usages = [], requires = [] } = req.body;
   try {
     const result = await pool.query(
-      'UPDATE parts SET number = $1, description = $2, usages = $3, requires = $4 WHERE id = $5 RETURNING *',
-      [number, description, usages, requires, id]
+      'UPDATE parts SET number = $1, description = $2, lx = $3, ly = $4, usages = $5, requires = $6 WHERE id = $7 RETURNING *',
+      [number, description, lx, ly, usages, requires, id]
     );
     if (result.rowCount === 0) return res.status(404).json({ error: 'Part not found' });
     res.json({ part: result.rows[0] });

--- a/backend/tests/parts.test.js
+++ b/backend/tests/parts.test.js
@@ -10,44 +10,44 @@ describe('Parts API', () => {
   });
 
   test('lists parts filtered by usage', async () => {
-    pool.query.mockResolvedValueOnce({ rows: [{ id: 1, number: 'E0086', usages: ['topRail', 'bottomRail'], requires: null }] });
+    pool.query.mockResolvedValueOnce({ rows: [{ id: 1, number: 'E0086', description: null, lx: null, ly: null, usages: ['topRail', 'bottomRail'], requires: null }] });
 
     const res = await request(app).get('/api/parts?usage=topRail');
 
     expect(res.status).toBe(200);
-    expect(res.body.parts).toEqual([{ id: 1, number: 'E0086', usages: ['topRail', 'bottomRail'], requires: null }]);
+    expect(res.body.parts).toEqual([{ id: 1, number: 'E0086', description: null, lx: null, ly: null, usages: ['topRail', 'bottomRail'], requires: null }]);
     expect(pool.query).toHaveBeenCalledWith('SELECT * FROM parts WHERE $1 = ANY(usages) ORDER BY number', ['topRail']);
   });
 
   test('adds a part', async () => {
-    const part = { id: 1, number: 'E0057', description: null, usages: ['hingeRail'], requires: [] };
+    const part = { id: 1, number: 'E0057', description: null, lx: 1, ly: 2, usages: ['hingeRail'], requires: [] };
     pool.query.mockResolvedValueOnce({ rows: [part] });
 
     const res = await request(app)
       .post('/api/parts')
-      .send({ number: 'E0057', description: null, usages: ['hingeRail'], requires: [] });
+      .send({ number: 'E0057', description: null, lx: 1, ly: 2, usages: ['hingeRail'], requires: [] });
 
     expect(res.status).toBe(200);
     expect(res.body.part).toEqual(part);
     expect(pool.query).toHaveBeenCalledWith(
-      'INSERT INTO parts (number, description, usages, requires) VALUES ($1, $2, $3, $4) RETURNING *',
-      ['E0057', null, ['hingeRail'], []]
+      'INSERT INTO parts (number, description, lx, ly, usages, requires) VALUES ($1, $2, $3, $4, $5, $6) RETURNING *',
+      ['E0057', null, 1, 2, ['hingeRail'], []]
     );
   });
 
   test('updates a part', async () => {
-    const part = { id: 1, number: 'E0057', description: '', usages: ['hingeRail'], requires: [] };
+    const part = { id: 1, number: 'E0057', description: '', lx: 1, ly: 2, usages: ['hingeRail'], requires: [] };
     pool.query.mockResolvedValueOnce({ rows: [part], rowCount: 1 });
 
     const res = await request(app)
       .put('/api/parts/1')
-      .send({ number: 'E0057', description: '', usages: ['hingeRail'], requires: [] });
+      .send({ number: 'E0057', description: '', lx: 1, ly: 2, usages: ['hingeRail'], requires: [] });
 
     expect(res.status).toBe(200);
     expect(res.body.part).toEqual(part);
     expect(pool.query).toHaveBeenCalledWith(
-      'UPDATE parts SET number = $1, description = $2, usages = $3, requires = $4 WHERE id = $5 RETURNING *',
-      ['E0057', '', ['hingeRail'], [], '1']
+      'UPDATE parts SET number = $1, description = $2, lx = $3, ly = $4, usages = $5, requires = $6 WHERE id = $7 RETURNING *',
+      ['E0057', '', 1, 2, ['hingeRail'], [], '1']
     );
   });
 

--- a/frontend/css/style.css
+++ b/frontend/css/style.css
@@ -306,3 +306,92 @@ body.dark .modal-body {
 .part-row button {
   margin-top: 0;
 }
+
+/* Tabs for data management */
+.tabs {
+  display: flex;
+  gap: 8px;
+  margin-top: 8px;
+  flex-wrap: wrap;
+}
+.tabs button {
+  flex: 1;
+  background: var(--vos-gray);
+  color: var(--vos-dark);
+  border: none;
+  padding: 8px 12px;
+  border-radius: 4px;
+  cursor: pointer;
+  text-transform: uppercase;
+}
+.tabs button.active {
+  background: var(--vos-red);
+  color: var(--vos-white);
+}
+body.dark .tabs button {
+  background: #333;
+  color: var(--vos-gray);
+}
+body.dark .tabs button.active {
+  background: var(--vos-red-dark);
+  color: var(--vos-white);
+}
+.tab-content { margin-top: 12px; }
+
+/* Dark mode toggle slider */
+.dark-toggle {
+  position: fixed;
+  bottom: 20px;
+  right: 20px;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  background: var(--vos-white);
+  border: 1px solid var(--vos-red);
+  padding: 4px 8px;
+  border-radius: 20px;
+  z-index: 1000;
+}
+body.dark .dark-toggle {
+  background: #333;
+  border-color: var(--vos-gray);
+}
+.switch {
+  position: relative;
+  display: inline-block;
+  width: 40px;
+  height: 20px;
+}
+.switch input {
+  opacity: 0;
+  width: 0;
+  height: 0;
+}
+.slider {
+  position: absolute;
+  cursor: pointer;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: var(--vos-gray);
+  transition: 0.4s;
+  border-radius: 20px;
+}
+.slider:before {
+  position: absolute;
+  content: '';
+  height: 16px;
+  width: 16px;
+  left: 2px;
+  bottom: 2px;
+  background-color: var(--vos-white);
+  transition: 0.4s;
+  border-radius: 50%;
+}
+.switch input:checked + .slider {
+  background-color: var(--vos-red);
+}
+.switch input:checked + .slider:before {
+  transform: translateX(20px);
+}

--- a/frontend/data.html
+++ b/frontend/data.html
@@ -9,64 +9,103 @@
 <body>
   <h1>Data Management</h1>
   <a href="index.html">Back to Job Manager</a>
-  <div class="panel">
-    <h2>Project Managers</h2>
-    <div id="pmList" class="list"></div>
-    <label for="newPmName">Add Project Manager</label>
-    <input id="newPmName" type="text" />
-    <button id="addPm">Add</button>
-  </div>
-  <div class="panel">
-    <h2>Door Part Templates</h2>
-    <div id="templateList" class="list"></div>
-    <label for="newTemplateName">Template Name</label>
-    <input id="newTemplateName" type="text" />
-    <label for="newTopRail">Top Rail</label>
-    <select id="newTopRail"></select>
-    <label for="newBottomRail">Bottom Rail</label>
-    <select id="newBottomRail"></select>
-    <label for="newHingeRail">Hinge Rail</label>
-    <select id="newHingeRail"></select>
-    <label for="newLockRail">Lock Rail</label>
-    <select id="newLockRail"></select>
-    <button id="addTemplate">Add Template</button>
+
+  <div id="dataTabs" class="tabs">
+    <button data-tab="pmTab" class="active">Project Managers</button>
+    <button data-tab="templatesTab">Door Part Templates</button>
+    <button data-tab="partsTab">Parts</button>
+    <button data-tab="frameTab">Frame Parts</button>
+    <button data-tab="hardwareTab">Hardware</button>
   </div>
 
-  <div class="panel">
-    <h2>Parts</h2>
-    <div id="partList" class="list"></div>
-    <label for="newPartNumber">Part Number</label>
-    <input id="newPartNumber" type="text" />
-    <div>
-      <p><strong>Door Parts</strong></p>
-      <label class="checkbox"><input id="newUsageTop" type="checkbox" /> Top Rail</label>
-      <label class="checkbox"><input id="newUsageBottom" type="checkbox" /> Bottom Rail</label>
-      <label class="checkbox"><input id="newUsageHinge" type="checkbox" /> Hinge Rail</label>
-      <label class="checkbox"><input id="newUsageLock" type="checkbox" /> Lock Rail</label>
-      <label class="checkbox"><input id="newUsageMid" type="checkbox" /> Mid Rail</label>
-      <label class="checkbox"><input id="newUsageGlass" type="checkbox" /> Glass Stop</label>
-      <label class="checkbox"><input id="newUsageDoorBacker" type="checkbox" /> Backer</label>
-      <p><strong>Frame Parts</strong></p>
-      <label class="checkbox"><input id="newUsageHingeJamb" type="checkbox" /> Hinge Jamb</label>
-      <label class="checkbox"><input id="newUsageLockJamb" type="checkbox" /> Lock Jamb</label>
-      <label class="checkbox"><input id="newUsageDoorHeader" type="checkbox" /> Door Header</label>
-      <label class="checkbox"><input id="newUsageTransomHeader" type="checkbox" /> Transom Header</label>
-      <label class="checkbox"><input id="newUsageDoorStop" type="checkbox" /> Door Stop</label>
-      <label class="checkbox"><input id="newUsageFrameBacker" type="checkbox" /> Backer</label>
+  <div id="pmTab" class="tab-content active">
+    <div class="panel">
+      <h2>Project Managers</h2>
+      <div id="pmList" class="list"></div>
+      <label for="newPmName">Add Project Manager</label>
+      <input id="newPmName" type="text" />
+      <button id="addPm">Add</button>
     </div>
-    <label for="newPartRequires">Requires (comma-separated)</label>
-    <input id="newPartRequires" type="text" />
-    <button id="addPart">Add Part</button>
   </div>
 
-  <div class="panel">
-    <h2>Frame Parts</h2>
-    <p class="muted">Coming soon...</p>
+  <div id="templatesTab" class="tab-content">
+    <div class="panel">
+      <h2>Door Part Templates</h2>
+      <div id="templateList" class="list"></div>
+      <label for="newTemplateName">Template Name</label>
+      <input id="newTemplateName" type="text" />
+      <label for="newTopRail">Top Rail</label>
+      <select id="newTopRail"></select>
+      <label for="newBottomRail">Bottom Rail</label>
+      <select id="newBottomRail"></select>
+      <label for="newHingeRail">Hinge Rail</label>
+      <select id="newHingeRail"></select>
+      <label for="newLockRail">Lock Rail</label>
+      <select id="newLockRail"></select>
+      <button id="addTemplate">Add Template</button>
+    </div>
   </div>
-  <div class="panel">
-    <h2>Hardware</h2>
-    <p class="muted">Coming soon...</p>
+
+  <div id="partsTab" class="tab-content">
+    <div class="panel">
+      <h2>Parts</h2>
+      <div id="partList" class="list"></div>
+      <label for="newPartNumber">Part Number</label>
+      <input id="newPartNumber" type="text" />
+      <label for="newPartDescription">Description</label>
+      <input id="newPartDescription" type="text" />
+      <label for="newPartLX">LX</label>
+      <input id="newPartLX" type="number" step="any" />
+      <label for="newPartLY">LY</label>
+      <input id="newPartLY" type="number" step="any" />
+      <div>
+        <p><strong>Door Parts</strong></p>
+        <label class="checkbox"><input id="newUsageTop" type="checkbox" /> Top Rail</label>
+        <label class="checkbox"><input id="newUsageBottom" type="checkbox" /> Bottom Rail</label>
+        <label class="checkbox"><input id="newUsageHinge" type="checkbox" /> Hinge Rail</label>
+        <label class="checkbox"><input id="newUsageLock" type="checkbox" /> Lock Rail</label>
+        <label class="checkbox"><input id="newUsageMid" type="checkbox" /> Mid Rail</label>
+        <label class="checkbox"><input id="newUsageGlass" type="checkbox" /> Glass Stop</label>
+        <label class="checkbox"><input id="newUsageDoorBacker" type="checkbox" /> Backer</label>
+        <label class="checkbox"><input id="newUsageLug" type="checkbox" /> Lugs</label>
+        <label class="checkbox"><input id="newUsageFastener" type="checkbox" /> Fasteners</label>
+        <p><strong>Frame Parts</strong></p>
+        <label class="checkbox"><input id="newUsageHingeJamb" type="checkbox" /> Hinge Jamb</label>
+        <label class="checkbox"><input id="newUsageLockJamb" type="checkbox" /> Lock Jamb</label>
+        <label class="checkbox"><input id="newUsageDoorHeader" type="checkbox" /> Door Header</label>
+        <label class="checkbox"><input id="newUsageTransomHeader" type="checkbox" /> Transom Header</label>
+        <label class="checkbox"><input id="newUsageDoorStop" type="checkbox" /> Door Stop</label>
+        <label class="checkbox"><input id="newUsageFrameBacker" type="checkbox" /> Backer</label>
+      </div>
+      <label for="newPartRequires">Requires (comma-separated)</label>
+      <input id="newPartRequires" type="text" />
+      <button id="addPart">Add Part</button>
+    </div>
+  </div>
+
+  <div id="frameTab" class="tab-content">
+    <div class="panel">
+      <h2>Frame Parts</h2>
+      <p class="muted">Coming soon...</p>
+    </div>
+  </div>
+
+  <div id="hardwareTab" class="tab-content">
+    <div class="panel">
+      <h2>Hardware</h2>
+      <p class="muted">Coming soon...</p>
+    </div>
+  </div>
+
+  <div class="dark-toggle">
+    <span>☀️</span>
+    <label class="switch">
+      <input type="checkbox" id="toggleDarkMode" />
+      <span class="slider"></span>
+    </label>
+    <span>🌙</span>
   </div>
   <script src="js/data.js"></script>
+  <script src="js/theme.js"></script>
 </body>
 </html>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -15,8 +15,7 @@
 </head>
 <body>
   <h1>Job Manager (Frontend)</h1>
-  <button id="toggleDarkMode">Toggle Dark Mode</button>
-  <a href="data.html">Data Management</a>
+    <a href="data.html">Data Management</a>
   <div class="row">
     <div class="col panel">
       <h2>Job Info</h2>
@@ -147,8 +146,17 @@
     </div>
   </div>
 </div>
+  <div class="dark-toggle">
+    <span>☀️</span>
+    <label class="switch">
+      <input type="checkbox" id="toggleDarkMode">
+      <span class="slider"></span>
+    </label>
+    <span>🌙</span>
+  </div>
   <script src="js/doorPartPresets.js"></script>
   <script src="js/app.js"></script>
   <script src="js/pdf.js"></script>
+  <script src="js/theme.js"></script>
 </body>
 </html>

--- a/frontend/js/app.js
+++ b/frontend/js/app.js
@@ -627,15 +627,3 @@ document.getElementById('exportJsonDownload').addEventListener('click', async ()
 });
 
 refreshJobList('', viewArchivedEl.checked);
-
-const darkBtn = document.getElementById('toggleDarkMode');
-if (darkBtn) {
-  if (localStorage.getItem('darkMode') === '1') {
-    document.body.classList.add('dark');
-    document.body
-  }
-  darkBtn.addEventListener('click', () => {
-    document.body.classList.toggle('dark');
-    localStorage.setItem('darkMode', document.body.classList.contains('dark') ? '1' : '0');
-  });
-}

--- a/frontend/js/theme.js
+++ b/frontend/js/theme.js
@@ -1,0 +1,11 @@
+(function(){
+  const checkbox = document.getElementById('toggleDarkMode');
+  if (!checkbox) return;
+  const apply = (enabled) => {
+    document.body.classList.toggle('dark', enabled);
+    checkbox.checked = enabled;
+    localStorage.setItem('darkMode', enabled ? '1' : '0');
+  };
+  apply(localStorage.getItem('darkMode') === '1');
+  checkbox.addEventListener('change', () => apply(checkbox.checked));
+})();


### PR DESCRIPTION
## Summary
- Replace dark mode button with bottom-right slider using sun and moon icons and shared script
- Convert maintenance console into tabbed layout with dark mode support and additional part fields
- Allow storing part dimensions and description with new backend support and tests

## Testing
- `cd backend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a11768ef588329873a88d623ad1d20