### PR TITLE
Move work order and entry management to page-level tabs

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -16,51 +16,41 @@
 <body>
   <h1>Job Manager (Frontend)</h1>
     <a href="data.html">Data Management</a>
-  <div class="row">
-    <div class="col panel">
-      <h2>Jobs</h2>
-      <label>Filter</label>
-      <input id="filterJobs" type="text" placeholder="type job number or name..." />
-      <label class="checkbox"><input id="viewArchived" type="checkbox" /> View Archived</label>
-      <select id="jobsSelect" size="10" class="job-select"></select>
-      <div class="action-buttons">
-        <button id="addJob">Add New Job</button>
-        <button id="editSelected">Edit Job</button>
-        <button id="deleteSelected">Delete Selected</button>
-        <button id="loadJobs">Refresh Job List</button>
-      </div>
-      <div class="section">
-        <button id="exportJsonDownload">Download All Data (JSON)</button>
-      </div>
-      <div class="muted note">
-        Note: CSV import is done server-side and stored in Postgres. PDF generation happens in your browser using jsPDF.
+
+  <div id="mainTabs" class="tabs">
+    <button id="jobsTabBtn" class="active" data-tab="jobsTab">Jobs</button>
+    <button id="workOrdersTabBtn" data-tab="workOrdersTab">Work Orders</button>
+    <button id="entriesTabBtn" data-tab="entriesTab">Entries</button>
+  </div>
+
+  <div id="jobsTab" class="tab-content" style="display:block;">
+    <div class="row">
+      <div class="col panel">
+        <h2>Jobs</h2>
+        <label>Filter</label>
+        <input id="filterJobs" type="text" placeholder="type job number or name..." />
+        <label class="checkbox"><input id="viewArchived" type="checkbox" /> View Archived</label>
+        <select id="jobsSelect" size="10" class="job-select"></select>
+        <div class="action-buttons">
+          <button id="addJob">Add New Job</button>
+          <button id="editSelected">Edit Job</button>
+          <button id="deleteSelected">Delete Selected</button>
+          <button id="loadJobs">Refresh Job List</button>
+        </div>
+        <div class="section">
+          <button id="exportJsonDownload">Download All Data (JSON)</button>
+        </div>
+        <div class="muted note">
+          Note: CSV import is done server-side and stored in Postgres. PDF generation happens in your browser using jsPDF.
+        </div>
       </div>
     </div>
   </div>
 
-  <!-- modal for job info -->
-  <div id="jobModal" class="modal-overlay">
-    <div class="modal-body">
-      <h3>Job Info</h3>
-      <div id="jobModalTabs" class="tabs">
-        <button id="jobInfoTabBtn" class="active" data-tab="jobInfoTab">Job</button>
-        <button id="workOrdersTabBtn" data-tab="workOrdersTab">Work Orders</button>
-        <button id="entriesTabBtn" data-tab="entriesTab">Entries</button>
-      </div>
-      <div id="jobInfoTab" class="tab-content" style="display:block;">
-        <input id="jobId" type="hidden" />
-        <label>Job Number</label>
-        <input id="jobNumber" type="text" />
-        <label>Job Name</label>
-        <input id="jobName" type="text" />
-        <label>PM</label>
-        <select id="pm"></select>
-        <label class="checkbox"><input id="archived" type="checkbox" /> Archived</label>
-        <div class="action-buttons">
-          <button id="saveJob">Save Job</button>
-        </div>
-      </div>
-      <div id="workOrdersTab" class="tab-content">
+  <div id="workOrdersTab" class="tab-content">
+    <div class="row">
+      <div class="col panel">
+        <h2>Work Orders</h2>
         <div class="action-buttons">
           <input id="newWorkOrder" type="text" placeholder="Work Order #" />
           <button id="addWorkOrder">Add Work Order</button>
@@ -70,11 +60,35 @@
           <button id="exportPdfWorkOrder">Export PDF (Selected)</button>
         </div>
       </div>
-      <div id="entriesTab" class="tab-content">
+    </div>
+  </div>
+
+  <div id="entriesTab" class="tab-content">
+    <div class="row">
+      <div class="col panel">
+        <h2>Entries</h2>
         <div class="action-buttons">
           <button id="addEntry">Add Entry</button>
         </div>
         <div id="entriesList" class="list"></div>
+      </div>
+    </div>
+  </div>
+
+  <!-- modal for job info -->
+  <div id="jobModal" class="modal-overlay">
+    <div class="modal-body">
+      <h3>Job Info</h3>
+      <input id="jobId" type="hidden" />
+      <label>Job Number</label>
+      <input id="jobNumber" type="text" />
+      <label>Job Name</label>
+      <input id="jobName" type="text" />
+      <label>PM</label>
+      <select id="pm"></select>
+      <label class="checkbox"><input id="archived" type="checkbox" /> Archived</label>
+      <div class="action-buttons">
+        <button id="saveJob">Save Job</button>
       </div>
       <div class="modal-actions">
         <button id="jobModalClose">Close</button>

--- a/frontend/js/app.js
+++ b/frontend/js/app.js
@@ -11,28 +11,28 @@ let selectedWorkOrderId = null;
 let editingEntry = null;
 
 const jobModal = document.getElementById('jobModal');
-const jobInfoTabBtn = document.getElementById('jobInfoTabBtn');
+const jobsTabBtn = document.getElementById('jobsTabBtn');
 const workOrdersTabBtn = document.getElementById('workOrdersTabBtn');
 const entriesTabBtn = document.getElementById('entriesTabBtn');
-const jobInfoTab = document.getElementById('jobInfoTab');
+const jobsTab = document.getElementById('jobsTab');
 const workOrdersTab = document.getElementById('workOrdersTab');
 const entriesTab = document.getElementById('entriesTab');
 
-function showJobModalTab(tab) {
-  jobInfoTab.style.display = tab === 'job' ? 'block' : 'none';
+function showMainTab(tab) {
+  jobsTab.style.display = tab === 'jobs' ? 'block' : 'none';
   workOrdersTab.style.display = tab === 'workorders' ? 'block' : 'none';
   entriesTab.style.display = tab === 'entries' ? 'block' : 'none';
-  jobInfoTabBtn.classList.toggle('active', tab === 'job');
+  jobsTabBtn.classList.toggle('active', tab === 'jobs');
   workOrdersTabBtn.classList.toggle('active', tab === 'workorders');
   entriesTabBtn.classList.toggle('active', tab === 'entries');
 }
 
-jobInfoTabBtn.addEventListener('click', () => showJobModalTab('job'));
-workOrdersTabBtn.addEventListener('click', () => showJobModalTab('workorders'));
-entriesTabBtn.addEventListener('click', () => showJobModalTab('entries'));
+jobsTabBtn.addEventListener('click', () => showMainTab('jobs'));
+workOrdersTabBtn.addEventListener('click', () => showMainTab('workorders'));
+entriesTabBtn.addEventListener('click', () => showMainTab('entries'));
+showMainTab('jobs');
 
 function openJobModal() {
-  showJobModalTab('job');
   jobModal.style.display = 'flex';
 }
 
@@ -182,7 +182,7 @@ function renderWorkOrders(workOrders = []) {
       selectedWorkOrderId = wo.id;
       renderWorkOrders(loadedJob.workOrders);
       renderEntries(wo.entries);
-      showJobModalTab('entries');
+      showMainTab('entries');
     };
     right.appendChild(openBtn);
     const editBtn = document.createElement('button'); editBtn.textContent = 'Edit';


### PR DESCRIPTION
## Summary
- Add page-level tabs for Jobs, Work Orders, and Entries
- Simplify job modal to only edit job info
- Switch to new tab handling logic and auto-show Entries tab when a work order is opened

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a11ed4e8448329afcb2c059045af18