### PR TITLE
Simplify usage checkbox handling in data manager

### DIFF
--- a/frontend/js/data.js
+++ b/frontend/js/data.js
@@ -194,8 +194,7 @@ document.getElementById('addPart').onclick = async () => {
   const lx = lxVal ? parseFloat(lxVal) : null;
   const ly = lyVal ? parseFloat(lyVal) : null;
   const usages = [];
-  document.querySelectorAll('.door-parts .usage-checkbox:checked').forEach(cb => usages.push(cb.value));
-  document.querySelectorAll('.frame-parts .usage-checkbox:checked').forEach(cb => usages.push(cb.value));
+  document.querySelectorAll('.usage-checkbox:checked').forEach(cb => usages.push(cb.value));
   const reqStr = document.getElementById('newPartRequires').value.trim();
   const requires = reqStr ? reqStr.split(',').map(s => s.trim()).filter(Boolean) : [];
   await api('/parts', { method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify({ number, description, lx, ly, usages, requires }) });
@@ -203,8 +202,7 @@ document.getElementById('addPart').onclick = async () => {
   document.getElementById('newPartDescription').value = '';
   document.getElementById('newPartLX').value = '';
   document.getElementById('newPartLY').value = '';
-  document.querySelectorAll('.door-parts .usage-checkbox').forEach(cb => cb.checked = false);
-  document.querySelectorAll('.frame-parts .usage-checkbox').forEach(cb => cb.checked = false);
+  document.querySelectorAll('.usage-checkbox').forEach(cb => cb.checked = false);
   document.getElementById('newPartRequires').value = '';
   loadParts();
 };


### PR DESCRIPTION
## Summary
- Ensure all part usage checkboxes in `data.html` use the `usage-checkbox` class
- Simplify part creation by looping through `.usage-checkbox` elements for collecting and clearing selections

## Testing
- `npm test` (in `backend`)

------
https://chatgpt.com/codex/tasks/task_e_68a12baa20fc83298a8dd6e5e5ad55e3