### PR TITLE
Add description and expanded uses fields to part modal

### DIFF
--- a/frontend/data.html
+++ b/frontend/data.html
@@ -68,6 +68,33 @@
       <input id="partLzInput" type="number" step="any" />
       <label for="partLyInput">LY</label>
       <input id="partLyInput" type="number" step="any" />
+      <label for="partDescriptionInput">Description</label>
+      <textarea id="partDescriptionInput"></textarea>
+      <fieldset id="partDoorUses">
+        <legend>Door Uses</legend>
+        <label><input type="checkbox" value="topRail" /> topRail</label>
+        <label><input type="checkbox" value="bottomRail" /> bottomRail</label>
+        <label><input type="checkbox" value="hingeRail" /> hingeRail</label>
+        <label><input type="checkbox" value="lockRail" /> lockRail</label>
+        <label><input type="checkbox" value="glassStop" /> glassStop</label>
+        <label><input type="checkbox" value="lug" /> lug</label>
+        <label><input type="checkbox" value="midRail" /> midRail</label>
+        <label><input type="checkbox" value="reinforcement" /> reinforcement</label>
+        <label><input type="checkbox" value="fasteners" /> fasteners</label>
+      </fieldset>
+      <fieldset id="partFrameUses">
+        <legend>Frame Uses</legend>
+        <label><input type="checkbox" value="hingeJamb" /> hingeJamb</label>
+        <label><input type="checkbox" value="lockJamb" /> lockJamb</label>
+        <label><input type="checkbox" value="doorHead" /> doorHead</label>
+        <label><input type="checkbox" value="transomHead" /> transomHead</label>
+        <label><input type="checkbox" value="threshold" /> threshold</label>
+        <label><input type="checkbox" value="transomStop" /> transomStop</label>
+        <label><input type="checkbox" value="doorStop" /> doorStop</label>
+        <label><input type="checkbox" value="reinforcement" /> reinforcement</label>
+        <label><input type="checkbox" value="fasteners" /> fasteners</label>
+        <label><input type="checkbox" value="shearClips" /> shearClips</label>
+      </fieldset>
       <label for="partDataInput">Data (JSON)</label>
       <textarea id="partDataInput"></textarea>
       <div class="action-buttons">

--- a/frontend/js/data.js
+++ b/frontend/js/data.js
@@ -163,6 +163,11 @@ function openPartModal(part) {
   document.getElementById('partTypeInput').value = part?.part_type || '';
   document.getElementById('partLzInput').value = part?.part_lz || '';
   document.getElementById('partLyInput').value = part?.part_ly || '';
+  document.getElementById('partDescriptionInput').value = part?.data?.description || '';
+  const uses = part?.data?.uses || [];
+  document.querySelectorAll('#partDoorUses input[type="checkbox"], #partFrameUses input[type="checkbox"]').forEach(cb => {
+    cb.checked = uses.includes(cb.value);
+  });
   document.getElementById('partDataInput').value = part?.data ? JSON.stringify(part.data) : '';
   partModal.style.display = 'flex';
 }
@@ -195,10 +200,16 @@ document.getElementById('savePart').onclick = async () => {
   const partLz = lzVal ? parseFloat(lzVal) : null;
   const partLy = lyVal ? parseFloat(lyVal) : null;
   const dataTxt = document.getElementById('partDataInput').value.trim();
-  let data = null;
+  const description = document.getElementById('partDescriptionInput').value.trim();
+  const uses = Array.from(document.querySelectorAll('#partDoorUses input:checked, #partFrameUses input:checked')).map(cb => cb.value);
+  let data = {};
   if (dataTxt) {
     try { data = JSON.parse(dataTxt); } catch (e) { return alert('Invalid JSON'); }
   }
+  if (description) data.description = description;
+  const uniqueUses = [...new Set(uses)];
+  if (uniqueUses.length) data.uses = uniqueUses;
+  if (Object.keys(data).length === 0) data = null;
   const payload = { partType, partLz, partLy, data };
   const res = id
     ? await api(`/parts/${id}`, { method: 'PUT', headers: { 'content-type': 'application/json' }, body: JSON.stringify(payload) })


### PR DESCRIPTION
## Summary
- Split part uses into door and frame sections with additional options
- Populate and save description and uses across both sections

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a13604189c8329bfc31823f0bfb873