### PR TITLE
Fix parts modal and filter template options

### DIFF
--- a/frontend/js/app.js
+++ b/frontend/js/app.js
@@ -443,7 +443,14 @@ doorPartPreset.addEventListener('change', () => {
 async function loadPartsCache() {
   if (partsCache) return partsCache;
   const res = await api('/parts');
-  partsCache = res.ok ? res.json.parts || [] : [];
+  partsCache = res.ok
+    ? (res.json.parts || []).map(p => ({
+        ...p,
+        number: p.part_type,
+        usages: p.data?.uses || [],
+        requires: p.data?.requires || []
+      }))
+    : [];
   return partsCache;
 }
 

--- a/frontend/js/data.js
+++ b/frontend/js/data.js
@@ -27,8 +27,8 @@ for (const btn of document.querySelectorAll('#dataTabs button')) {
 }
 
 
-function populateRailSelect(selectEl, current) {
-  const parts = partsCache || [];
+function populateRailSelect(selectEl, usage, current) {
+  const parts = (partsCache || []).filter(p => (p.data?.uses || []).includes(usage));
   selectEl.innerHTML = '<option value=""></option>';
   parts.forEach(p => {
     const opt = document.createElement('option');
@@ -138,10 +138,10 @@ async function loadParts() {
   if (res.ok) {
     partsCache = res.json.parts || [];
     renderParts(partsCache);
-    populateRailSelect(topRailSelect);
-    populateRailSelect(bottomRailSelect);
-    populateRailSelect(hingeRailSelect);
-    populateRailSelect(lockRailSelect);
+    populateRailSelect(topRailSelect, 'topRail');
+    populateRailSelect(bottomRailSelect, 'bottomRail');
+    populateRailSelect(hingeRailSelect, 'hingeRail');
+    populateRailSelect(lockRailSelect, 'lockRail');
   }
 }
 


### PR DESCRIPTION
## Summary
- Map backend part data to include part numbers, uses, and requirements for frontend
- Filter door part template selections by use categories

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a13c896ed08329814c7d3faee7a0ef