### PR TITLE
Add part dependency and quantity fields

### DIFF
--- a/backend/migrations.sql
+++ b/backend/migrations.sql
@@ -74,8 +74,13 @@ CREATE TABLE IF NOT EXISTS door_parts (
     part_type VARCHAR(255),
     part_lz NUMERIC,
     part_ly NUMERIC,
-    data JSONB
+    data JSONB,
+    requires TEXT[],
+    quantity INT DEFAULT 1
 );
+
+ALTER TABLE door_parts ADD COLUMN IF NOT EXISTS requires TEXT[];
+ALTER TABLE door_parts ADD COLUMN IF NOT EXISTS quantity INT DEFAULT 1;
 
 -- Legacy parts table removed; door_parts table now stores generic parts as well
 DROP TABLE IF EXISTS parts;

--- a/backend/src/routes.js
+++ b/backend/src/routes.js
@@ -344,11 +344,11 @@ router.get('/parts', async (req, res) => {
 
 // Create a part
 router.post('/parts', async (req, res) => {
-  const { partType, partLz = null, partLy = null, data = null } = req.body;
+  const { partType, partLz = null, partLy = null, data = null, requires = null, quantity = 1 } = req.body;
   try {
     const result = await pool.query(
-      'INSERT INTO door_parts (door_id, part_type, part_lz, part_ly, data) VALUES ($1, $2, $3, $4, $5) RETURNING *',
-      [null, partType, partLz, partLy, data]
+      'INSERT INTO door_parts (door_id, part_type, part_lz, part_ly, data, requires, quantity) VALUES ($1, $2, $3, $4, $5, $6, $7) RETURNING *',
+      [null, partType, partLz, partLy, data, requires, quantity]
     );
     res.json({ part: result.rows[0] });
   } catch (err) {
@@ -359,11 +359,11 @@ router.post('/parts', async (req, res) => {
 // Update a part
 router.put('/parts/:id', async (req, res) => {
   const id = req.params.id;
-  const { partType, partLz = null, partLy = null, data = null } = req.body;
+  const { partType, partLz = null, partLy = null, data = null, requires = null, quantity = 1 } = req.body;
   try {
     const result = await pool.query(
-      'UPDATE door_parts SET part_type = $1, part_lz = $2, part_ly = $3, data = $4 WHERE id = $5 AND door_id IS NULL RETURNING *',
-      [partType, partLz, partLy, data, id]
+      'UPDATE door_parts SET part_type = $1, part_lz = $2, part_ly = $3, data = $4, requires = $5, quantity = $6 WHERE id = $7 AND door_id IS NULL RETURNING *',
+      [partType, partLz, partLy, data, requires, quantity, id]
     );
     if (result.rowCount === 0) return res.status(404).json({ error: 'Part not found' });
     res.json({ part: result.rows[0] });
@@ -482,11 +482,11 @@ router.get('/doors/:id/parts', async (req, res) => {
 // Add a part to a door
 router.post('/doors/:id/parts', async (req, res) => {
   const doorId = req.params.id;
-  const { partType, partLz, partLy, data } = req.body;
+  const { partType, partLz, partLy, data, requires = null, quantity = 1 } = req.body;
   try {
     const result = await pool.query(
-      'INSERT INTO door_parts (door_id, part_type, part_lz, part_ly, data) VALUES ($1, $2, $3, $4, $5) RETURNING *',
-      [doorId, partType, partLz, partLy, data]
+      'INSERT INTO door_parts (door_id, part_type, part_lz, part_ly, data, requires, quantity) VALUES ($1, $2, $3, $4, $5, $6, $7) RETURNING *',
+      [doorId, partType, partLz, partLy, data, requires, quantity]
     );
     res.json({ part: result.rows[0] });
   } catch (err) {
@@ -497,11 +497,11 @@ router.post('/doors/:id/parts', async (req, res) => {
 // Update a door part
 router.put('/door-parts/:id', async (req, res) => {
   const id = req.params.id;
-  const { partType, partLz, partLy, data } = req.body;
+  const { partType, partLz, partLy, data, requires = null, quantity = 1 } = req.body;
   try {
     const result = await pool.query(
-      'UPDATE door_parts SET part_type = $1, part_lz = $2, part_ly = $3, data = $4 WHERE id = $5 RETURNING *',
-      [partType, partLz, partLy, data, id]
+      'UPDATE door_parts SET part_type = $1, part_lz = $2, part_ly = $3, data = $4, requires = $5, quantity = $6 WHERE id = $7 RETURNING *',
+      [partType, partLz, partLy, data, requires, quantity, id]
     );
     if (result.rowCount === 0) return res.status(404).json({ error: 'Door part not found' });
     res.json({ part: result.rows[0] });

--- a/backend/tests/door-parts.test.js
+++ b/backend/tests/door-parts.test.js
@@ -17,6 +17,8 @@ describe('Door Parts API', () => {
       part_lz: 1.25,
       part_ly: 2.5,
       data: { foo: 'bar' },
+      requires: null,
+      quantity: 1,
     };
 
     pool.query.mockResolvedValueOnce({ rows: [part] });
@@ -28,8 +30,8 @@ describe('Door Parts API', () => {
     expect(res.status).toBe(200);
     expect(res.body.part).toEqual(part);
     expect(pool.query).toHaveBeenCalledWith(
-      'INSERT INTO door_parts (door_id, part_type, part_lz, part_ly, data) VALUES ($1, $2, $3, $4, $5) RETURNING *',
-      ['1', 'hinge', 1.25, 2.5, { foo: 'bar' }]
+      'INSERT INTO door_parts (door_id, part_type, part_lz, part_ly, data, requires, quantity) VALUES ($1, $2, $3, $4, $5, $6, $7) RETURNING *',
+      ['1', 'hinge', 1.25, 2.5, { foo: 'bar' }, null, 1]
     );
   });
 
@@ -41,6 +43,8 @@ describe('Door Parts API', () => {
       part_lz: 2,
       part_ly: 3,
       data: { baz: 'qux' },
+      requires: null,
+      quantity: 1,
     };
 
     pool.query.mockResolvedValueOnce({ rows: [part], rowCount: 1 });
@@ -52,8 +56,8 @@ describe('Door Parts API', () => {
     expect(res.status).toBe(200);
     expect(res.body.part).toEqual(part);
     expect(pool.query).toHaveBeenCalledWith(
-      'UPDATE door_parts SET part_type = $1, part_lz = $2, part_ly = $3, data = $4 WHERE id = $5 RETURNING *',
-      ['hinge', 2, 3, { baz: 'qux' }, '1']
+      'UPDATE door_parts SET part_type = $1, part_lz = $2, part_ly = $3, data = $4, requires = $5, quantity = $6 WHERE id = $7 RETURNING *',
+      ['hinge', 2, 3, { baz: 'qux' }, null, 1, '1']
     );
   });
 

--- a/backend/tests/parts.test.js
+++ b/backend/tests/parts.test.js
@@ -10,17 +10,17 @@ describe('Parts API', () => {
   });
 
   test('lists parts', async () => {
-    pool.query.mockResolvedValueOnce({ rows: [{ id: 1, door_id: null, part_type: 'E0086', part_lz: null, part_ly: null, data: null }] });
+    pool.query.mockResolvedValueOnce({ rows: [{ id: 1, door_id: null, part_type: 'E0086', part_lz: null, part_ly: null, data: null, requires: null, quantity: 1 }] });
 
     const res = await request(app).get('/api/parts');
 
     expect(res.status).toBe(200);
-    expect(res.body.parts).toEqual([{ id: 1, door_id: null, part_type: 'E0086', part_lz: null, part_ly: null, data: null }]);
+    expect(res.body.parts).toEqual([{ id: 1, door_id: null, part_type: 'E0086', part_lz: null, part_ly: null, data: null, requires: null, quantity: 1 }]);
     expect(pool.query).toHaveBeenCalledWith('SELECT * FROM door_parts WHERE door_id IS NULL ORDER BY part_type');
   });
 
   test('adds a part', async () => {
-    const part = { id: 1, door_id: null, part_type: 'E0057', part_lz: 1, part_ly: 2, data: null };
+    const part = { id: 1, door_id: null, part_type: 'E0057', part_lz: 1, part_ly: 2, data: null, requires: null, quantity: 1 };
     pool.query.mockResolvedValueOnce({ rows: [part] });
 
     const res = await request(app)
@@ -30,13 +30,13 @@ describe('Parts API', () => {
     expect(res.status).toBe(200);
     expect(res.body.part).toEqual(part);
     expect(pool.query).toHaveBeenCalledWith(
-      'INSERT INTO door_parts (door_id, part_type, part_lz, part_ly, data) VALUES ($1, $2, $3, $4, $5) RETURNING *',
-      [null, 'E0057', 1, 2, null]
+      'INSERT INTO door_parts (door_id, part_type, part_lz, part_ly, data, requires, quantity) VALUES ($1, $2, $3, $4, $5, $6, $7) RETURNING *',
+      [null, 'E0057', 1, 2, null, null, 1]
     );
   });
 
   test('updates a part', async () => {
-    const part = { id: 1, door_id: null, part_type: 'E0057', part_lz: 1, part_ly: 2, data: null };
+    const part = { id: 1, door_id: null, part_type: 'E0057', part_lz: 1, part_ly: 2, data: null, requires: null, quantity: 1 };
     pool.query.mockResolvedValueOnce({ rows: [part], rowCount: 1 });
 
     const res = await request(app)
@@ -46,8 +46,8 @@ describe('Parts API', () => {
     expect(res.status).toBe(200);
     expect(res.body.part).toEqual(part);
     expect(pool.query).toHaveBeenCalledWith(
-      'UPDATE door_parts SET part_type = $1, part_lz = $2, part_ly = $3, data = $4 WHERE id = $5 AND door_id IS NULL RETURNING *',
-      ['E0057', 1, 2, null, '1']
+      'UPDATE door_parts SET part_type = $1, part_lz = $2, part_ly = $3, data = $4, requires = $5, quantity = $6 WHERE id = $7 AND door_id IS NULL RETURNING *',
+      ['E0057', 1, 2, null, null, 1, '1']
     );
   });
 

--- a/frontend/data.html
+++ b/frontend/data.html
@@ -104,6 +104,10 @@
       <input id="partLyInput" type="number" step="any" />
       <label for="partDescriptionInput">Description</label>
       <textarea id="partDescriptionInput"></textarea>
+      <label for="partQuantityInput">Quantity</label>
+      <input id="partQuantityInput" type="number" min="1" step="1" />
+      <label for="partRequiresInput">Requires (comma separated)</label>
+      <input id="partRequiresInput" type="text" />
       <fieldset id="partDoorUses">
         <legend>Door Uses</legend>
         <label><input type="checkbox" value="topRail" /> Top Rail</label>

--- a/frontend/js/app.js
+++ b/frontend/js/app.js
@@ -456,7 +456,8 @@ async function loadPartsCache() {
         ...p,
         number: p.part_type,
         usages: p.data?.uses || [],
-        requires: p.data?.requires || []
+        requires: p.requires || [],
+        quantity: p.quantity || 1
       }))
     : [];
   return partsCache;

--- a/frontend/js/data.js
+++ b/frontend/js/data.js
@@ -195,6 +195,8 @@ function openPartModal(part) {
   document.getElementById('partLzInput').value = part?.part_lz || '';
   document.getElementById('partLyInput').value = part?.part_ly || '';
   document.getElementById('partDescriptionInput').value = part?.data?.description || '';
+  document.getElementById('partQuantityInput').value = part?.quantity || 1;
+  document.getElementById('partRequiresInput').value = (part?.requires || []).join(',');
   const uses = part?.data?.uses || [];
   document.querySelectorAll('#partDoorUses input[type="checkbox"], #partFrameUses input[type="checkbox"]').forEach(cb => {
     cb.checked = uses.includes(cb.value);
@@ -230,13 +232,17 @@ document.getElementById('savePart').onclick = async () => {
   const partLz = lzVal ? parseFloat(lzVal) : null;
   const partLy = lyVal ? parseFloat(lyVal) : null;
   const description = document.getElementById('partDescriptionInput').value.trim();
+  const quantityVal = document.getElementById('partQuantityInput').value;
+  const quantity = quantityVal ? parseInt(quantityVal, 10) : 1;
+  const requiresVal = document.getElementById('partRequiresInput').value.trim();
+  const requires = requiresVal ? requiresVal.split(',').map(s => s.trim()).filter(Boolean) : null;
   const uses = Array.from(document.querySelectorAll('#partDoorUses input:checked, #partFrameUses input:checked')).map(cb => cb.value);
   let data = {};
   if (description) data.description = description;
   const uniqueUses = [...new Set(uses)];
   if (uniqueUses.length) data.uses = uniqueUses;
   if (Object.keys(data).length === 0) data = null;
-  const payload = { partType, partLz, partLy, data };
+  const payload = { partType, partLz, partLy, data, requires, quantity };
   const res = id
     ? await api(`/parts/${id}`, { method: 'PUT', headers: { 'content-type': 'application/json' }, body: JSON.stringify(payload) })
     : await api('/parts', { method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify(payload) });


### PR DESCRIPTION
## Summary
- allow tracking required parts and quantities on door parts
- expose new fields in API and UI management console
- expand tests for updated door_parts schema

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a3c3b55a74832986a2d35047e17a22