### PR TITLE
feat: add part requirement rows

### DIFF
--- a/frontend/data.html
+++ b/frontend/data.html
@@ -104,8 +104,8 @@
       <input id="partLyInput" type="number" step="any" />
       <label for="partDescriptionInput">Description</label>
       <textarea id="partDescriptionInput"></textarea>
-      <label for="partRequiresInput">Requires (format part:qty, comma separated)</label>
-      <input id="partRequiresInput" type="text" />
+      <label for="partRequiresContainer">Requires</label>
+      <div id="partRequiresContainer"></div>
       <fieldset id="partDoorUses">
         <legend>Door Uses</legend>
         <label><input type="checkbox" value="topRail" /> Top Rail</label>


### PR DESCRIPTION
## Summary
- support editing multiple required parts via dynamic rows instead of single text input
- gather requirement quantities when saving parts

## Testing
- `npm test` (fails: Door Parts API adds a door part - expected query without quantity)


------
https://chatgpt.com/codex/tasks/task_e_68a3ccce44ec83298e444f386aa720bd