### PR TITLE
Refactor frontend API helper into shared module

### DIFF
--- a/backend/tests/api.test.js
+++ b/backend/tests/api.test.js
@@ -1,0 +1,27 @@
+describe('api helper', () => {
+  afterEach(() => {
+    delete global.APP_CONFIG;
+    delete global.fetch;
+    delete global.location;
+    jest.resetModules();
+  });
+
+  test('uses relative path when apiBase matches origin', () => {
+    global.location = { origin: 'http://localhost' };
+    global.APP_CONFIG = { apiBase: 'http://localhost' };
+    jest.resetModules();
+    const { API_BASE } = require('../../frontend/js/api.js');
+    expect(API_BASE).toBe('');
+  });
+
+  test('prefixes requests with apiBase when provided', async () => {
+    global.location = { origin: 'http://localhost' };
+    global.APP_CONFIG = { apiBase: 'https://backend.example.com' };
+    jest.resetModules();
+    const { API_BASE, api } = require('../../frontend/js/api.js');
+    expect(API_BASE).toBe('https://backend.example.com');
+    global.fetch = jest.fn().mockResolvedValue({ ok: true, text: () => Promise.resolve('{}'), status: 200 });
+    await api('/jobs');
+    expect(global.fetch).toHaveBeenCalledWith('https://backend.example.com/api/jobs', {});
+  });
+});

--- a/frontend/data.html
+++ b/frontend/data.html
@@ -212,6 +212,7 @@
     </label>
     <span>🌙</span>
   </div>
+  <script src="js/api.js"></script>
   <script src="js/data.js"></script>
   <script src="js/theme.js"></script>
 </body>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -204,6 +204,7 @@
     <span>🌙</span>
   </div>
   <script src="js/doorPartPresets.js"></script>
+  <script src="js/api.js"></script>
   <script src="js/app.js"></script>
   <script src="js/theme.js"></script>
 </body>

--- a/frontend/js/api.js
+++ b/frontend/js/api.js
@@ -1,0 +1,17 @@
+(function(root){
+  const API_ORIGIN = root.APP_CONFIG?.apiBase || root.location.origin;
+  const API_BASE = API_ORIGIN === root.location.origin ? '' : API_ORIGIN;
+  async function api(path, opts = {}) {
+    const r = await fetch(API_BASE + '/api' + path, opts);
+    const txt = await r.text();
+    try { return { ok: r.ok, json: JSON.parse(txt), status: r.status }; }
+    catch (e) { return { ok: r.ok, text: txt, status: r.status }; }
+  }
+  if (typeof module !== 'undefined' && module.exports) {
+    module.exports = { api, API_BASE, API_ORIGIN };
+  } else {
+    root.api = api;
+    root.API_BASE = API_BASE;
+    root.API_ORIGIN = API_ORIGIN;
+  }
+})(typeof window !== 'undefined' ? window : globalThis);

--- a/frontend/js/app.js
+++ b/frontend/js/app.js
@@ -1,12 +1,3 @@
-const API_ORIGIN = window.APP_CONFIG?.apiBase || window.location.origin;
-const API_BASE = API_ORIGIN === window.location.origin ? '' : API_ORIGIN; // use relative paths when same origin
-function api(path, opts = {}) {
-  return fetch(API_BASE + '/api' + path, opts).then(async r => {
-    const txt = await r.text();
-    try { return { ok: r.ok, json: JSON.parse(txt), status: r.status }; } catch(e) { return { ok: r.ok, text: txt, status: r.status }; }
-  });
-}
-
 let loadedJob = null;
 let selectedWorkOrderId = null;
 let editingEntry = null;

--- a/frontend/js/data.js
+++ b/frontend/js/data.js
@@ -1,12 +1,3 @@
-const API_ORIGIN = window.APP_CONFIG?.apiBase || window.location.origin;
-const API_BASE = API_ORIGIN === window.location.origin ? '' : API_ORIGIN; // same base as main app
-function api(path, opts = {}) {
-  return fetch(API_BASE + '/api' + path, opts).then(async r => {
-    const txt = await r.text();
-    try { return { ok: r.ok, json: JSON.parse(txt), status: r.status }; } catch(e) { return { ok: r.ok, text: txt, status: r.status }; }
-  });
-}
-
 let partsCache = [];
 let pmCache = [];
 let templateCache = [];


### PR DESCRIPTION
## Summary
- factor out duplicate API helper into standalone `api.js` used across frontend
- update HTML pages to include shared API helper
- add tests verifying API base URL logic

## Testing
- `cd backend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a3dfea77148329ad9207148bce8eaf