### PR TITLE
Add hardware variable definitions to hardware library

### DIFF
--- a/backend/migrations.sql
+++ b/backend/migrations.sql
@@ -77,5 +77,6 @@ CREATE TABLE IF NOT EXISTS hardware_items (
     category_id INT REFERENCES hardware_categories(id) ON DELETE SET NULL,
     manufacturer VARCHAR(255),
     model_number VARCHAR(255),
-    features JSONB
+    features JSONB,
+    variables JSONB
 );

--- a/backend/src/routes.js
+++ b/backend/src/routes.js
@@ -595,11 +595,11 @@ router.get('/hardware', async (req, res) => {
 
 // Create a hardware item
 router.post('/hardware', async (req, res) => {
-  const { categoryId, manufacturer, modelNumber, features } = req.body;
+  const { categoryId, manufacturer, modelNumber, features, variables } = req.body;
   try {
     const result = await pool.query(
-      'INSERT INTO hardware_items (category_id, manufacturer, model_number, features) VALUES ($1, $2, $3, $4) RETURNING *',
-      [categoryId, manufacturer, modelNumber, features]
+      'INSERT INTO hardware_items (category_id, manufacturer, model_number, features, variables) VALUES ($1, $2, $3, $4, $5) RETURNING *',
+      [categoryId, manufacturer, modelNumber, features, variables]
     );
     res.json({ hardware: result.rows[0] });
   } catch (err) {
@@ -610,11 +610,11 @@ router.post('/hardware', async (req, res) => {
 // Update a hardware item
 router.put('/hardware/:id', async (req, res) => {
   const id = req.params.id;
-  const { categoryId, manufacturer, modelNumber, features } = req.body;
+  const { categoryId, manufacturer, modelNumber, features, variables } = req.body;
   try {
     const result = await pool.query(
-      'UPDATE hardware_items SET category_id = $1, manufacturer = $2, model_number = $3, features = $4 WHERE id = $5 RETURNING *',
-      [categoryId, manufacturer, modelNumber, features, id]
+      'UPDATE hardware_items SET category_id = $1, manufacturer = $2, model_number = $3, features = $4, variables = $5 WHERE id = $6 RETURNING *',
+      [categoryId, manufacturer, modelNumber, features, variables, id]
     );
     if (result.rowCount === 0) return res.status(404).json({ error: 'Hardware not found' });
     res.json({ hardware: result.rows[0] });

--- a/backend/tests/hardware.test.js
+++ b/backend/tests/hardware.test.js
@@ -54,7 +54,7 @@ describe('Hardware API', () => {
   });
 
   test('lists hardware items', async () => {
-    const rows = [{ id: 1, category_id: 2, manufacturer: 'Acme', model_number: 'H123', features: ['fire-rated'] }];
+    const rows = [{ id: 1, category_id: 2, manufacturer: 'Acme', model_number: 'H123', features: ['fire-rated'], variables: ['backset'] }];
     pool.query.mockResolvedValueOnce({ rows });
 
     const res = await request(app).get('/api/hardware');
@@ -65,34 +65,34 @@ describe('Hardware API', () => {
   });
 
   test('adds a hardware item', async () => {
-    const item = { id: 1, category_id: 2, manufacturer: 'Acme', model_number: 'H123', features: ['fire-rated'] };
+    const item = { id: 1, category_id: 2, manufacturer: 'Acme', model_number: 'H123', features: ['fire-rated'], variables: ['backset'] };
     pool.query.mockResolvedValueOnce({ rows: [item] });
 
     const res = await request(app)
       .post('/api/hardware')
-      .send({ categoryId: 2, manufacturer: 'Acme', modelNumber: 'H123', features: ['fire-rated'] });
+      .send({ categoryId: 2, manufacturer: 'Acme', modelNumber: 'H123', features: ['fire-rated'], variables: ['backset'] });
 
     expect(res.status).toBe(200);
     expect(res.body.hardware).toEqual(item);
     expect(pool.query).toHaveBeenCalledWith(
-      'INSERT INTO hardware_items (category_id, manufacturer, model_number, features) VALUES ($1, $2, $3, $4) RETURNING *',
-      [2, 'Acme', 'H123', ['fire-rated']]
+      'INSERT INTO hardware_items (category_id, manufacturer, model_number, features, variables) VALUES ($1, $2, $3, $4, $5) RETURNING *',
+      [2, 'Acme', 'H123', ['fire-rated'], ['backset']]
     );
   });
 
   test('updates a hardware item', async () => {
-    const item = { id: 1, category_id: 3, manufacturer: 'Acme', model_number: 'P200', features: [] };
+    const item = { id: 1, category_id: 3, manufacturer: 'Acme', model_number: 'P200', features: [], variables: ['centerAff'] };
     pool.query.mockResolvedValueOnce({ rows: [item], rowCount: 1 });
 
     const res = await request(app)
       .put('/api/hardware/1')
-      .send({ categoryId: 3, manufacturer: 'Acme', modelNumber: 'P200', features: [] });
+      .send({ categoryId: 3, manufacturer: 'Acme', modelNumber: 'P200', features: [], variables: ['centerAff'] });
 
     expect(res.status).toBe(200);
     expect(res.body.hardware).toEqual(item);
     expect(pool.query).toHaveBeenCalledWith(
-      'UPDATE hardware_items SET category_id = $1, manufacturer = $2, model_number = $3, features = $4 WHERE id = $5 RETURNING *',
-      [3, 'Acme', 'P200', [], '1']
+      'UPDATE hardware_items SET category_id = $1, manufacturer = $2, model_number = $3, features = $4, variables = $5 WHERE id = $6 RETURNING *',
+      [3, 'Acme', 'P200', [], ['centerAff'], '1']
     );
   });
 

--- a/frontend/data.html
+++ b/frontend/data.html
@@ -167,6 +167,8 @@
       <input id="hardwareModelInput" type="text" />
       <label for="hardwareFeaturesInput">Features (comma separated)</label>
       <input id="hardwareFeaturesInput" type="text" />
+      <label for="hardwareVariablesInput">Variables (comma separated)</label>
+      <input id="hardwareVariablesInput" type="text" />
       <div class="action-buttons">
         <button id="saveHardwareItem">Save Hardware</button>
       </div>

--- a/frontend/js/data.js
+++ b/frontend/js/data.js
@@ -388,8 +388,13 @@ function renderHardwareItems(items) {
     const opt = document.createElement('option');
     opt.value = h.id;
     const feat = (h.features || []).join(', ');
+    const vars = (h.variables || []).join(', ');
+    const parts = [];
     const text = `${h.manufacturer || ''} ${h.model_number || ''}`.trim();
-    opt.textContent = feat ? `${text} — ${feat}` : text;
+    if (text) parts.push(text);
+    if (feat) parts.push(feat);
+    if (vars) parts.push(vars);
+    opt.textContent = parts.join(' — ');
     hardwareItemSelect.appendChild(opt);
   });
 }
@@ -400,6 +405,7 @@ function openHardwareItemModal(h) {
   document.getElementById('hardwareManufacturerInput').value = h?.manufacturer || '';
   document.getElementById('hardwareModelInput').value = h?.model_number || '';
   document.getElementById('hardwareFeaturesInput').value = h?.features ? h.features.join(', ') : '';
+  document.getElementById('hardwareVariablesInput').value = h?.variables ? h.variables.join(', ') : '';
   hardwareItemModal.style.display = 'flex';
 }
 
@@ -425,8 +431,10 @@ document.getElementById('saveHardwareItem').onclick = async () => {
   const manufacturer = document.getElementById('hardwareManufacturerInput').value.trim();
   const modelNumber = document.getElementById('hardwareModelInput').value.trim();
   const featuresTxt = document.getElementById('hardwareFeaturesInput').value.trim();
+  const variablesTxt = document.getElementById('hardwareVariablesInput').value.trim();
   const features = featuresTxt ? featuresTxt.split(',').map(f => f.trim()).filter(Boolean) : [];
-  const payload = { categoryId: parseInt(categoryId, 10), manufacturer, modelNumber, features };
+  const variables = variablesTxt ? variablesTxt.split(',').map(v => v.trim()).filter(Boolean) : [];
+  const payload = { categoryId: parseInt(categoryId, 10), manufacturer, modelNumber, features, variables };
   const res = id
     ? await api(`/hardware/${id}`, { method: 'PUT', headers: { 'content-type': 'application/json' }, body: JSON.stringify(payload) })
     : await api('/hardware', { method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify(payload) });


### PR DESCRIPTION
## Summary
- allow hardware items to store an array of variables used on door/frame sheets
- expose variables in hardware API and data management UI
- extend tests for new variables field

## Testing
- `npm test --prefix backend`

------
https://chatgpt.com/codex/tasks/task_e_68a46fcdab608329bf14ba88286bfda0